### PR TITLE
2/6 Mobile: viewport meta tags + normalized compensating CSS

### DIFF
--- a/webcdi/cdi_forms/static/cdi_forms/base.css
+++ b/webcdi/cdi_forms/static/cdi_forms/base.css
@@ -12,64 +12,49 @@
 }
 
 
-@media (max-width:991px){
-  body {
-    font-family: "Roboto", "sans-serif";
-    font-size: 40px;
-  }
-
-  label.btn span {
-    font-size: 2.3em;
-  }
-  a.btn, input.btn {
-    font-size:1em;
-  }
-
-  h1 { font-size: 1.5em; }
-  h2 { font-size: 1.3em; }
-  h3 { font-size: 1.15em; }
-  h4 { font-size: 1.1em; }
-  h5 { font-size: .83em; }
-  h6 { font-size: .75em; }
-
-  legend { font-size: 1.1em; }
-
-}
-
-@media (min-width:992px) and (max-width:1199px) {
-  body {
-    font-family: "Roboto", "sans-serif";
-    font-size: 24px;
-  }
-  label.btn span {
-    font-size: 1.9em;
-  }
-  a.btn, input.btn {
-    font-size:1em;
-  }
-
-  h1 { font-size: 2em; }
-  h2 { font-size: 1.2em; }
-  h3 { font-size: 1.15em; }
-  h4 { font-size: 1.1em; }
-  h5 { font-size: .83em; }
-  h6 { font-size: .75em; }
+/* Font sizes assume a proper viewport meta tag (width=device-width) on
+   every page that loads this file. The old 40px/24px small-screen sizes
+   compensated for pages rendering in the ~980px fallback viewport and
+   being scaled down; they must not come back. */
+body {
+  font-family: "Roboto", "sans-serif";
+  font-size: 16px;
 }
 
 @media (min-width:1200px){
-    body {
-      font-family: "Roboto", "sans-serif";
-      font-size: 18px;
-    }
-  label.btn span {
-    font-size: 1.1em;
+  body {
+    font-size: 18px;
   }
-  h1 { font-size: 2em; }
-  h2 { font-size: 1.5em; }
-  h3 { font-size: 1.17em; }
-  h4 { font-size: 1.12em; }
-  h5 { font-size: .83em; }
-  h6 { font-size: .75em; }
+}
+
+label.btn span {
+  font-size: 1.1em;
+}
+a.btn, input.btn {
+  font-size: 1em;
+}
+
+h1 { font-size: 2em; }
+h2 { font-size: 1.5em; }
+h3 { font-size: 1.17em; }
+h4 { font-size: 1.12em; }
+h5 { font-size: .83em; }
+h6 { font-size: .75em; }
+
+legend { font-size: 1.1em; }
+
+/* Comfortable touch targets on the item checklists */
+input[type=checkbox], input[type=radio] {
+  width: 1.25em;
+  height: 1.25em;
+}
+
+/* Breathing room on phones for pages without a Bootstrap container */
+@media (max-width:991px){
+  body {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
 }
 
 
@@ -83,11 +68,6 @@
     display: inline-block;
 }
 
-@media(max-width:1199px){.form-control { 
-    height: 1.9em;
-    font-size: 0.8em; 
-  }
-}
 
 .alco-child {
     margin: 10px;

--- a/webcdi/cdi_forms/static/cdi_forms/extra_mobile.css
+++ b/webcdi/cdi_forms/static/cdi_forms/extra_mobile.css
@@ -3,22 +3,18 @@ select.form-control:not([size]):not([multiple]) {
 }
 
 @media only screen and (max-width: 980px) {
-   
+
     .material-icons {
-        font-size: 46px
+        font-size: 28px
     }
-    
+
     .datepicker table tr td, .datepicker table tr th {
         text-align: center;
-        width: 60px;
-        height: 60px;
+        width: 40px;
+        height: 40px;
         border-radius: 4px;
         border: none;
-        font-size: 40px;
-    } 
-
-    select.form-control:not([size]):not([multiple]) {
-        height: calc(5.25rem + 2px);
+        font-size: 1em;
     }
 
     .modal-dialog {
@@ -26,8 +22,8 @@ select.form-control:not([size]):not([multiple]) {
     }
 
     .modal-footer > .btn {
-        padding: 2.5rem 2.75rem;
-        font-size: 2rem;
+        padding: 0.75rem 1.25rem;
+        font-size: 1.1em;
     }
 }
 

--- a/webcdi/cdi_forms/templates/cdi_forms/administration_base.html
+++ b/webcdi/cdi_forms/templates/cdi_forms/administration_base.html
@@ -8,6 +8,7 @@
 <html {% if language_code %}lang="{{ language_code }}"{% else %}lang="en"{% endif %}>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% trans title %}</title>
     <meta name="description" content="MacArthur-Bates Communicative Development Inventory">
 

--- a/webcdi/cdi_forms/templates/cdi_forms/cdi_base.html
+++ b/webcdi/cdi_forms/templates/cdi_forms/cdi_base.html
@@ -3,6 +3,7 @@
 <html {% if language_code %}lang="{{ language_code }}"{% else %}lang="en"{% endif %}>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     {% load i18n %}
     {% load static %}
 

--- a/webcdi/static/cdi_forms/base.css
+++ b/webcdi/static/cdi_forms/base.css
@@ -12,64 +12,49 @@
 }
 
 
-@media (max-width:991px){
-  body {
-    font-family: "Roboto", "sans-serif";
-    font-size: 40px;
-  }
-
-  label.btn span {
-    font-size: 2.3em;
-  }
-  a.btn, input.btn {
-    font-size:1em;
-  }
-
-  h1 { font-size: 1.5em; }
-  h2 { font-size: 1.3em; }
-  h3 { font-size: 1.15em; }
-  h4 { font-size: 1.1em; }
-  h5 { font-size: .83em; }
-  h6 { font-size: .75em; }
-
-  legend { font-size: 1.1em; }
-
-}
-
-@media (min-width:992px) and (max-width:1199px) {
-  body {
-    font-family: "Roboto", "sans-serif";
-    font-size: 24px;
-  }
-  label.btn span {
-    font-size: 1.9em;
-  }
-  a.btn, input.btn {
-    font-size:1em;
-  }
-
-  h1 { font-size: 2em; }
-  h2 { font-size: 1.2em; }
-  h3 { font-size: 1.15em; }
-  h4 { font-size: 1.1em; }
-  h5 { font-size: .83em; }
-  h6 { font-size: .75em; }
+/* Font sizes assume a proper viewport meta tag (width=device-width) on
+   every page that loads this file. The old 40px/24px small-screen sizes
+   compensated for pages rendering in the ~980px fallback viewport and
+   being scaled down; they must not come back. */
+body {
+  font-family: "Roboto", "sans-serif";
+  font-size: 16px;
 }
 
 @media (min-width:1200px){
-    body {
-      font-family: "Roboto", "sans-serif";
-      font-size: 18px;
-    }
-  label.btn span {
-    font-size: 1.1em;
+  body {
+    font-size: 18px;
   }
-  h1 { font-size: 2em; }
-  h2 { font-size: 1.5em; }
-  h3 { font-size: 1.17em; }
-  h4 { font-size: 1.12em; }
-  h5 { font-size: .83em; }
-  h6 { font-size: .75em; }
+}
+
+label.btn span {
+  font-size: 1.1em;
+}
+a.btn, input.btn {
+  font-size: 1em;
+}
+
+h1 { font-size: 2em; }
+h2 { font-size: 1.5em; }
+h3 { font-size: 1.17em; }
+h4 { font-size: 1.12em; }
+h5 { font-size: .83em; }
+h6 { font-size: .75em; }
+
+legend { font-size: 1.1em; }
+
+/* Comfortable touch targets on the item checklists */
+input[type=checkbox], input[type=radio] {
+  width: 1.25em;
+  height: 1.25em;
+}
+
+/* Breathing room on phones for pages without a Bootstrap container */
+@media (max-width:991px){
+  body {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
 }
 
 
@@ -83,11 +68,6 @@
     display: inline-block;
 }
 
-@media(max-width:1199px){.form-control { 
-    height: 1.9em;
-    font-size: 0.8em; 
-  }
-}
 
 .alco-child {
     margin: 10px;

--- a/webcdi/static/cdi_forms/extra_mobile.css
+++ b/webcdi/static/cdi_forms/extra_mobile.css
@@ -3,22 +3,18 @@ select.form-control:not([size]):not([multiple]) {
 }
 
 @media only screen and (max-width: 980px) {
-   
+
     .material-icons {
-        font-size: 46px
+        font-size: 28px
     }
-    
+
     .datepicker table tr td, .datepicker table tr th {
         text-align: center;
-        width: 60px;
-        height: 60px;
+        width: 40px;
+        height: 40px;
         border-radius: 4px;
         border: none;
-        font-size: 40px;
-    } 
-
-    select.form-control:not([size]):not([multiple]) {
-        height: calc(5.25rem + 2px);
+        font-size: 1em;
     }
 
     .modal-dialog {
@@ -26,8 +22,8 @@ select.form-control:not([size]):not([multiple]) {
     }
 
     .modal-footer > .btn {
-        padding: 2.5rem 2.75rem;
-        font-size: 2rem;
+        padding: 0.75rem 1.25rem;
+        font-size: 1.1em;
     }
 }
 

--- a/webcdi/webcdi/templates/registration/base.html
+++ b/webcdi/webcdi/templates/registration/base.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <html lang="en"> <head> <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% load static %}
 

--- a/webcdi/webcdi/templates/webcdi/home.html
+++ b/webcdi/webcdi/templates/webcdi/home.html
@@ -3,6 +3,7 @@
 <head lang="en">
 
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     {% load static %}
     <title>Web CDI</title>
 


### PR DESCRIPTION
Part of the six-PR stack (merge after #617).

The participant-facing base templates had no viewport meta tag, so phones rendered the ~980px fallback viewport scaled down — and the small-screen CSS compensated with 40px body text, 46px icons, and 60px datepicker cells. This change is necessarily coupled: viewport tags added to all four bases, font scale normalized (16px phone / 18px desktop), compensations removed, checkboxes enlarged to real tap targets, phone gutters added.

Verified by phone- and desktop-size screenshots of home, background-info, and the vocabulary checklist; also fixes desktop artifacts (truncated labels, overflowing sidebar buttons). Note both copies of each stylesheet change in sync (app source + the tracked STATIC_ROOT copy — see the tech-debt catalogue re: un-tracking collected static).

🤖 Generated with [Claude Code](https://claude.com/claude-code)