### PR TITLE
7/8 Security: fix the clinical-PDF exposure, SECRET_KEY from env, config hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,9 @@ TIME_ZONE=America/Los_Angeles
 CAT_ENGINE=browser
 
 # Optional overrides (defaults live in settings.py):
+# SECRET_KEY=           # Django signing key; REQUIRED in production (falls
+#                       # back to a locally generated secret_key.py file)
+# GOOGLE_ANALYTICS_ID=  # GA measurement ID; empty disables the snippet
 # CAT_API_URL=          # R-based CAT server; defaults to the production instance
 # AWS_STORAGE_BUCKET_NAME=   # required only when AWS_INSTANCE=True
 # TRUSTED_ORIGINS=      # CSRF trusted origins, same bracket format as ALLOWED_HOSTS

--- a/webcdi/cdi_forms/templates/cdi_forms/administration_base.html
+++ b/webcdi/cdi_forms/templates/cdi_forms/administration_base.html
@@ -50,14 +50,17 @@
     </script>
 
     {% block extra_css %}{% endblock %}
-        <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=328947117"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-    gtag('config', '328947117');
-    </script>
+        {% if GOOGLE_ANALYTICS_ID %}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS_ID }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ GOOGLE_ANALYTICS_ID }}');
+</script>
+{% endif %}
 </head>
 
 <body data-spy="scroll" data-target="#navbar">

--- a/webcdi/cdi_forms/templates/cdi_forms/cdi_base.html
+++ b/webcdi/cdi_forms/templates/cdi_forms/cdi_base.html
@@ -57,15 +57,17 @@
     </script>
 
     {% block extra_css %}{% endblock %}
-        <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=328947117"></script>
+        {% if GOOGLE_ANALYTICS_ID %}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS_ID }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', '328947117');
+  gtag('config', '{{ GOOGLE_ANALYTICS_ID }}');
 </script>
+{% endif %}
 </head>
 
 <body data-spy="scroll" data-target="#navbar">

--- a/webcdi/cdi_forms/views/administration_views.py
+++ b/webcdi/cdi_forms/views/administration_views.py
@@ -70,20 +70,7 @@ class AdministrationSummaryView(DetailView):
         ctx["gift_code"] = None
         ctx["gift_amount"] = None
         if self.object.study.allow_payment and self.object.bypass is None:
-            amazon_urls = {
-                "English": {
-                    "redeem_url": "http://www.amazon.com/redeem",
-                    "legal_url": "http://www.amazon.com/gc-legal",
-                },
-                "Spanish": {
-                    "redeem_url": "http://www.amazon.com/gc/redeem/?language=es_US",
-                    "legal_url": "http://www.amazon.com/gc-legal/?language=es_US",
-                },
-                "French Quebec": {
-                    "redeem_url": "http://www.amazon.ca/gc/redeem/?language=fr_CA",
-                    "legal_url": "http://www.amazon.ca/gc-legal/?language=fr_CA",
-                },
-            }
+            amazon_urls = settings.AMAZON_GIFT_CARD_URLS
             url_obj = amazon_urls.get(self.object.study.instrument.language)
             if url_obj is None:
                 url_obj = amazon_urls.get("English")

--- a/webcdi/researcher_UI/templates/researcher_UI/base.html
+++ b/webcdi/researcher_UI/templates/researcher_UI/base.html
@@ -28,15 +28,17 @@
     <script src="{% static 'cdi_forms/moment.js' %}"></script>
     <style>
     </style>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=328947117"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
+    {% if GOOGLE_ANALYTICS_ID %}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ GOOGLE_ANALYTICS_ID }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-        gtag('config', '328947117');
-    </script>
+  gtag('config', '{{ GOOGLE_ANALYTICS_ID }}');
+</script>
+{% endif %}
     {% block extra_head %}{% endblock %}
     
   </head>

--- a/webcdi/researcher_UI/tests/test_views/ajax_views.py
+++ b/webcdi/researcher_UI/tests/test_views/ajax_views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from django.test import TestCase, tag
 from django.urls import reverse
 
@@ -6,6 +7,9 @@ from researcher_UI.models import Instrument, InstrumentFamily
 
 class AjaxDemographicFormsTest(TestCase):
     def setUp(self):
+        # these endpoints are researcher-only (LoginRequiredMixin)
+        self.user = User.objects.create_user(username="researcher", password="secret")
+        self.client.force_login(self.user)
         self.url = reverse("researcher_ui:get_demographic_forms")
         instrument_family = InstrumentFamily.objects.create(
             name="BigCats", chargeable=True
@@ -32,6 +36,8 @@ class AjaxDemographicFormsTest(TestCase):
 
 class AjaxChargeStatusTest(TestCase):
     def setUp(self):
+        self.user = User.objects.create_user(username="researcher", password="secret")
+        self.client.force_login(self.user)
         instrument_family = InstrumentFamily.objects.create(
             name="BigCats", chargeable=True
         )

--- a/webcdi/researcher_UI/tests/test_views/download_data_views.py
+++ b/webcdi/researcher_UI/tests/test_views/download_data_views.py
@@ -17,6 +17,9 @@ class PDFAdministrationDetailViewTest(TestCase):
         self.user = User.objects.create_user(
             username="PaulMcCartney", password="PaulMcCartney"
         )
+        # the clinical PDF exposes child data; the view now requires the
+        # owning researcher to be logged in
+        self.client.force_login(self.user)
 
         instrument = Instrument.objects.filter(
             language="English",
@@ -71,3 +74,21 @@ class PDFAdministrationDetailViewTest(TestCase):
             )
         )
         self.assertEqual(response.status_code, 302)
+
+    def test_anonymous_is_redirected(self):
+        # child data must not be reachable without logging in
+        self.client.logout()
+        response = self.client.get(
+            f'{reverse("researcher_ui:pdf_summary", kwargs={"pk": self.study.id})}{self.ids}'
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login", response.url)
+
+    def test_other_researcher_cannot_access(self):
+        # a logged-in researcher cannot read another researcher's study
+        other = User.objects.create_user(username="RingoStarr", password="RingoStarr")
+        self.client.force_login(other)
+        response = self.client.get(
+            f'{reverse("researcher_ui:pdf_summary", kwargs={"pk": self.study.id})}{self.ids}'
+        )
+        self.assertEqual(response.status_code, 404)

--- a/webcdi/researcher_UI/views/ajax_views.py
+++ b/webcdi/researcher_UI/views/ajax_views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core import serializers
 from django.http import HttpResponse, JsonResponse
 from django.views.generic import DetailView
@@ -5,7 +6,7 @@ from django.views.generic import DetailView
 from researcher_UI.models import Instrument
 
 
-class AjaxDemographicForms(DetailView):
+class AjaxDemographicForms(LoginRequiredMixin, DetailView):
     def get(self, request):
         pk = request.GET["id"]
         try:
@@ -19,7 +20,7 @@ class AjaxDemographicForms(DetailView):
         return HttpResponse(data, content_type="application/json")
 
 
-class AjaxChargeStatus(DetailView):
+class AjaxChargeStatus(LoginRequiredMixin, DetailView):
     def get(self, request):
         pk = request.GET["id"]
 

--- a/webcdi/researcher_UI/views/download_data_views.py
+++ b/webcdi/researcher_UI/views/download_data_views.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.template.loader import get_template
@@ -15,8 +16,12 @@ from researcher_UI.models import Study
 logger = logging.getLogger("debug")
 
 
-class PDFAdministrationDetailView(WeasyTemplateResponseMixin, DetailView):
+class PDFAdministrationDetailView(LoginRequiredMixin, WeasyTemplateResponseMixin, DetailView):
     model = Study
+
+    def get_queryset(self):
+        # clinical reports contain child data: only the owning researcher
+        return Study.objects.filter(researcher=self.request.user)
 
     def get_template_names(self):
         name = slugify(f"{self.object.instrument.verbose_name}")

--- a/webcdi/researcher_UI/views/profile.py
+++ b/webcdi/researcher_UI/views/profile.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.models import User
 from django.contrib.auth.views import PasswordChangeView
@@ -14,7 +15,7 @@ from django.views.generic import UpdateView
 from researcher_UI.forms import ProfileForm, ResearcherForm
 
 
-class ProfileView(UpdateView):
+class ProfileView(LoginRequiredMixin, UpdateView):
     model = User
     form_class = ProfileForm
     template_name = "researcher_UI/profile.html"

--- a/webcdi/webcdi/context_processors.py
+++ b/webcdi/webcdi/context_processors.py
@@ -5,4 +5,5 @@ def home_page(request):
     return {
         "CONTACT_EMAIL": settings.CONTACT_EMAIL,
         "MORE_INFO_LINK": settings.MORE_INFO_ADDRESS,
+        "GOOGLE_ANALYTICS_ID": settings.GOOGLE_ANALYTICS_ID,
     }

--- a/webcdi/webcdi/middleware.py
+++ b/webcdi/webcdi/middleware.py
@@ -1,33 +1,9 @@
-import re
-
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
-from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
+from django.http import HttpResponsePermanentRedirect
 from django.urls import resolve
 from django.utils import translation
 from django.utils.deprecation import MiddlewareMixin
-from django.utils.http import url_has_allowed_host_and_scheme
-
-EXEMPT_URLS = [re.compile(settings.LOGIN_URL.lstrip("/"))]
-if hasattr(settings, "LOGIN_EXEMPT_URLS"):
-    EXEMPT_URLS += [re.compile(url) for url in settings.LOGIN_EXEMPT_URLS]
-
-
-class LoginRequiredMiddleware(MiddlewareMixin):
-    def process_request(self, request):
-        assert hasattr(request, "user"), "The Login Required Middleware"
-        if not request.user.is_authenticated:
-            path = request.path_info.lstrip("/")
-            if not any(m.match(path) for m in EXEMPT_URLS):
-                redirect_to = settings.LOGIN_URL
-                # 'next' variable to support redirection to attempted page after login
-                if len(path) > 0 and url_has_allowed_host_and_scheme(
-                    url=request.path_info, allowed_hosts=request.get_host()
-                ):
-                    redirect_to = f"{settings.LOGIN_URL}?next={request.path_info}"
-
-                return HttpResponseRedirect(redirect_to)
-
 
 class AdminLocaleMiddleware(MiddlewareMixin):
     def process_request(self, request):

--- a/webcdi/webcdi/settings.py
+++ b/webcdi/webcdi/settings.py
@@ -133,6 +133,25 @@ RECAPTCHA_PRIVATE_KEY = os.environ.get(
 CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "webcdi-contact@stanford.edu")
 MORE_INFO_ADDRESS = os.environ.get("MORE_INFO_ADDRESS", "http://mb-cdi.stanford.edu/")
 
+# Google Analytics measurement ID (empty string disables the snippet)
+GOOGLE_ANALYTICS_ID = os.environ.get("GOOGLE_ANALYTICS_ID", "328947117")
+
+# Gift-card redemption links shown to compensated participants
+AMAZON_GIFT_CARD_URLS = {
+    "English": {
+        "redeem_url": "http://www.amazon.com/redeem",
+        "legal_url": "http://www.amazon.com/gc-legal",
+    },
+    "Spanish": {
+        "redeem_url": "http://www.amazon.com/gc/redeem/?language=es_US",
+        "legal_url": "http://www.amazon.com/gc-legal/?language=es_US",
+    },
+    "French Quebec": {
+        "redeem_url": "http://www.amazon.ca/gc/redeem/?language=fr_CA",
+        "legal_url": "http://www.amazon.ca/gc-legal/?language=fr_CA",
+    },
+}
+
 # CAT Server
 CAT_API_BASE_URL = os.environ.get(
     "CAT_API_URL", "http://cdicatapi-env.eba-c2knb6uj.us-west-2.elasticbeanstalk.com/"
@@ -180,12 +199,18 @@ def generate_secret_key(fname):
 
 
 # SECURITY WARNING: keep the secret key used in production secret!
-try:
-    from .secret_key import *  # noqa
-except ImportError:
-    SETTINGS_DIR = os.path.abspath(os.path.dirname(__file__))
-    generate_secret_key(os.path.join(SETTINGS_DIR, "secret_key.py"))
-    from .secret_key import *  # noqa
+# Prefer the environment (set SECRET_KEY on the EB environment / in .env);
+# the generated-file fallback keeps existing deployments working but means
+# each fresh instance mints its own key (invalidating sessions), so
+# production should always set the env var.
+SECRET_KEY = os.environ.get("SECRET_KEY")
+if not SECRET_KEY:
+    try:
+        from .secret_key import *  # noqa
+    except ImportError:
+        SETTINGS_DIR = os.path.abspath(os.path.dirname(__file__))
+        generate_secret_key(os.path.join(SETTINGS_DIR, "secret_key.py"))
+        from .secret_key import *  # noqa
 
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10240
 
@@ -229,7 +254,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
-    "webcdi.middleware.LoginRequiredMiddleware",
     "webcdi.middleware.AdminLocaleMiddleware",
 ]
 
@@ -535,17 +559,10 @@ if private_ip:
 
 CAT_FORMS = ["CAT", "CAT2"]
 
-LOGIN_EXEMPT_URLS = (
-    r"^registration/logout/$",
-    r"^registration/register/$",
-    r"^registration/password-reset/$",
-    r"^registration/password-reset/done/$",
-    r"^registration/password-reset/confirm/",
-    r"^registration/password-reset/complete/$",
-    r"^registration/password/change/$",
-    r"^registration/password/change/",
-    r"^",
-)
+# NOTE: the old LoginRequiredMiddleware + LOGIN_EXEMPT_URLS pair was removed:
+# the exempt list ended with r"^" (matches every URL), so the middleware had
+# been a no-op. Access control lives on the views — researcher views use
+# LoginRequiredMixin; participant views are anonymous by design (hash URLs).
 
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"


### PR DESCRIPTION
Continues the stack (targets the jsCat PR's branch; merge after #622). Closes #626, #627 — and effectively #630.

**Please prioritize the review of this one.** The audit found a real exposure: the researcher clinical-report PDF view (which renders child data) was reachable by guessable study pk with **no authentication at all**. Everyone assumed the custom `LoginRequiredMiddleware` covered it, but that middleware was a no-op — its `LOGIN_EXEMPT_URLS` ended with `r"^"`, which matches every path. Worth checking whether any such PDF URL was ever shared outside the lab.

- **Clinical PDF view**: now `LoginRequiredMixin` + ownership-scoped (`get_queryset` filters `researcher=request.user`). New tests assert anonymous → redirect, non-owner → 404.
- **Also gated**: `ProfileView` and the two `/interface/ajax/` endpoints (this also converts their previous anonymous 500s — #630 — into clean redirects).
- **Dead code removed**: the no-op `LoginRequiredMiddleware` and `LOGIN_EXEMPT_URLS`, with a note in settings explaining that access control lives on the views (researcher views use `LoginRequiredMixin`; participant views are anonymous by hash-URL design).
- **Config**: `SECRET_KEY` read from the environment first (generated-file fallback kept; production should set the env var — each fresh instance minting its own key invalidates sessions). GA ID → `GOOGLE_ANALYTICS_ID` (empty disables the snippet). Amazon gift-card URLs → `settings.AMAZON_GIFT_CARD_URLS`.

Tests: 7 tests that had encoded the insecure behavior (hitting protected endpoints anonymously) now authenticate; targeted download/ajax/PDF suites green (38 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)