### PR TITLE
10/11 Make CAT tests hermetic (no live API), ~13 min → ~15 s

### DIFF
--- a/webcdi/cdi_forms/cat_forms/tests/cat_api_mock.py
+++ b/webcdi/cdi_forms/cat_forms/tests/cat_api_mock.py
@@ -1,0 +1,85 @@
+"""Hermetic replay of the R CAT API for the language CAT view tests.
+
+The per-language CAT tests replay a recorded item/response/theta sequence and
+assert the word shown at each step. They used to reach the *live* production R
+API to obtain each next item, which made the suite require a network connection
+and coupled it to whatever parameters happen to be deployed (that drift is what
+broke the Spanish sequence test). The recorded sequences are the ground truth
+the API is supposed to return, so replaying them locally exercises the full view
+flow — render, store answer, advance, stop, persist theta — with no network.
+
+Install with `install_sequence_api` / `install_start_api` inside a test; both
+register cleanup so the patch is torn down automatically.
+"""
+import csv
+import re
+from unittest import mock
+
+_PATCH_TARGET = "cdi_forms.cat_forms.views.cdi_cat_api"
+
+
+def _load(path):
+    with open(path, encoding="utf8") as f:
+        return list(csv.DictReader(f))
+
+
+def _administered_count(query_string):
+    """Number of items in a nextItem query's `items=[...]` list."""
+    m = re.search(r"items=\[([^\]]*)\]", query_string)
+    if not m:
+        return 0
+    inner = m.group(1).strip()
+    return 0 if not inner else len([x for x in inner.split(",") if x.strip()])
+
+
+def _theta4(value):
+    # the live API returned theta rounded to 4 decimals; the view stores it
+    # verbatim and the tests compare against the same 4-decimal rounding
+    return float("{:.4f}".format(float(value)))
+
+
+def _sequence_api(rows):
+    def fake(query_string):
+        if query_string.startswith("startItem"):
+            r = rows[0]
+            return {"index": int(r["index"]), "definition": r["item"],
+                    "stop": False, "curTheta": None}
+        if query_string.startswith("nextItem"):
+            n = _administered_count(query_string)
+            if n >= len(rows):
+                return {"stop": True, "definition": None, "index": None,
+                        "curTheta": _theta4(rows[-1]["theta"])}
+            r = rows[n]
+            return {"index": int(r["index"]), "definition": r["item"],
+                    "stop": False, "curTheta": _theta4(rows[n - 1]["theta"])}
+        # hardestWord / easiestWord: not asserted by the tests, return any item
+        r = rows[0]
+        return {"index": int(r["index"]), "definition": r["item"]}
+    return fake
+
+
+def _start_api(path):
+    by_age = {str(int(float(r["age"]))): r for r in _load(path)}
+    fallback = by_age.get("30") or next(iter(by_age.values()))
+
+    def fake(query_string):
+        m = re.search(r"age_mos=(\d+)", query_string)
+        r = by_age.get(m.group(1)) if m else None
+        r = r or fallback
+        return {"index": int(float(r["index"])), "definition": r["definition"],
+                "stop": False, "curTheta": float(r["theta"])}
+    return fake
+
+
+def install_sequence_api(testcase, sequence_path):
+    """Patch the view's cdi_cat_api to replay a recorded sequence CSV."""
+    patcher = mock.patch(_PATCH_TARGET, side_effect=_sequence_api(_load(sequence_path)))
+    patcher.start()
+    testcase.addCleanup(patcher.stop)
+
+
+def install_start_api(testcase, start_path):
+    """Patch the view's cdi_cat_api to answer startItem from a start-items CSV."""
+    patcher = mock.patch(_PATCH_TARGET, side_effect=_start_api(start_path))
+    patcher.start()
+    testcase.addCleanup(patcher.stop)

--- a/webcdi/cdi_forms/cat_forms/tests/dutch.py
+++ b/webcdi/cdi_forms/cat_forms/tests/dutch.py
@@ -5,7 +5,7 @@ import os
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management import call_command
-from django.test import TestCase, tag
+from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -13,6 +13,10 @@ from cdi_forms.cat_forms.forms import CatItemForm
 from cdi_forms.models import BackgroundInfo
 from researcher_UI.models import Administration, Instrument, Study
 from researcher_UI.tests.utils import random_password
+from cdi_forms.cat_forms.tests.cat_api_mock import (
+    install_sequence_api,
+    install_start_api,
+)
 
 
 def csv_reader(utf8_data, dialect=csv.excel, **kwargs):
@@ -28,6 +32,7 @@ def make_boolean(text):
 
 
 @tag("cat", "dutch")
+@override_settings(CAT_ENGINE="remote")
 class CATDutchAdministrationDataItemTest(TestCase):
     fixtures = [
         "researcher_UI/fixtures/researcher_UI_test_fixtures.json",
@@ -73,6 +78,7 @@ class CATDutchAdministrationDataItemTest(TestCase):
         )
 
     def start_values(self, file_name):
+        install_start_api(self, file_name)
         for age in range(12, 37):
             # read csv, and split on "," the line
             csv_file = csv.reader(open(os.path.realpath(file_name), "r"), delimiter=",")
@@ -94,6 +100,7 @@ class CATDutchAdministrationDataItemTest(TestCase):
             )
 
     def sequence_test(self, file_name):
+        install_sequence_api(self, file_name)
         response = self.client.get(self.url)
         contents = list(
             csv_reader(
@@ -137,17 +144,17 @@ class CATDutchAdministrationDataItemTest(TestCase):
                     float("{:.4f}".format(float(row[col_names.index("theta")]))),
                 )
 
-    def test_spanish_start_values(self):
+    def test_dutch_start_values(self):
         self.start_values(
             f"{settings.BASE_DIR}/cdi_forms/cat_forms/tests/test_data/dutch_start.csv"
         )
 
-    def test_spanish_seq_1(self):
+    def test_dutch_seq_1(self):
         self.sequence_test(
             f"{settings.BASE_DIR}/cdi_forms/cat_forms/tests/test_data/dutch_sequence_1.csv"
         )
 
-    def test_spanish_seq_2(self):
+    def test_dutch_seq_2(self):
         self.backgroundinfo.age = 28
         self.backgroundinfo.save()
         self.sequence_test(

--- a/webcdi/cdi_forms/cat_forms/tests/english.py
+++ b/webcdi/cdi_forms/cat_forms/tests/english.py
@@ -4,7 +4,7 @@ import os
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.test import TestCase, tag
+from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -12,6 +12,10 @@ from cdi_forms.cat_forms.forms import CatItemForm
 from cdi_forms.models import BackgroundInfo
 from researcher_UI.models import Administration, Instrument, Study
 from researcher_UI.tests.utils import random_password
+from cdi_forms.cat_forms.tests.cat_api_mock import (
+    install_sequence_api,
+    install_start_api,
+)
 
 
 def csv_reader(utf8_data, dialect=csv.excel, **kwargs):
@@ -27,6 +31,7 @@ def make_boolean(text):
 
 
 @tag("cat")
+@override_settings(CAT_ENGINE="remote")
 class CATEnglishAdministrationDataItemTest(TestCase):
     fixtures = [
         "researcher_UI/fixtures/researcher_UI_test_fixtures.json",
@@ -68,6 +73,7 @@ class CATEnglishAdministrationDataItemTest(TestCase):
         )
 
     def start_values(self, file_name):
+        install_start_api(self, file_name)
         for age in range(12, 37):
             # read csv, and split on "," the line
             csv_file = csv.reader(open(os.path.realpath(file_name), "r"), delimiter=",")
@@ -90,6 +96,7 @@ class CATEnglishAdministrationDataItemTest(TestCase):
         )
 
     def sequence_test(self, file_name):
+        install_sequence_api(self, file_name)
         response = self.client.get(self.url)
 
         contents = list(

--- a/webcdi/cdi_forms/cat_forms/tests/french.py
+++ b/webcdi/cdi_forms/cat_forms/tests/french.py
@@ -4,7 +4,7 @@ import os
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.test import TestCase, tag
+from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -12,6 +12,10 @@ from cdi_forms.cat_forms.forms import CatItemForm
 from cdi_forms.models import BackgroundInfo
 from researcher_UI.models import Administration, Instrument, Study
 from researcher_UI.tests.utils import random_password
+from cdi_forms.cat_forms.tests.cat_api_mock import (
+    install_sequence_api,
+    install_start_api,
+)
 
 
 def csv_reader(utf8_data, dialect=csv.excel, **kwargs):
@@ -27,6 +31,7 @@ def make_boolean(text):
 
 
 @tag("cat")
+@override_settings(CAT_ENGINE="remote")
 class CATFrenchAdministrationDataItemTest(TestCase):
     fixtures = [
         "researcher_UI/fixtures/researcher_UI_test_fixtures.json",
@@ -68,6 +73,7 @@ class CATFrenchAdministrationDataItemTest(TestCase):
         )
 
     def start_values(self, file_name):
+        install_start_api(self, file_name)
         for age in range(12, 37):
             # read csv, and split on "," the line
             csv_file = csv.reader(open(os.path.realpath(file_name), "r"), delimiter=",")
@@ -87,6 +93,7 @@ class CATFrenchAdministrationDataItemTest(TestCase):
             )
 
     def sequence_test(self, file_name):
+        install_sequence_api(self, file_name)
         response = self.client.get(self.url)
 
         contents = list(

--- a/webcdi/cdi_forms/cat_forms/tests/japanese.py
+++ b/webcdi/cdi_forms/cat_forms/tests/japanese.py
@@ -4,7 +4,7 @@ import os
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.test import TestCase, tag
+from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -12,6 +12,10 @@ from cdi_forms.cat_forms.forms import CatItemForm
 from cdi_forms.models import BackgroundInfo
 from researcher_UI.models import Administration, Instrument, Study
 from researcher_UI.tests.utils import random_password
+from cdi_forms.cat_forms.tests.cat_api_mock import (
+    install_sequence_api,
+    install_start_api,
+)
 
 
 def csv_reader(utf8_data, dialect=csv.excel, **kwargs):
@@ -27,6 +31,7 @@ def make_boolean(text):
 
 
 @tag("cat")
+@override_settings(CAT_ENGINE="remote")
 class CATJapaneseAdministrationDataItemTest(TestCase):
     fixtures = [
         "researcher_UI/fixtures/researcher_UI_test_fixtures.json",
@@ -68,6 +73,7 @@ class CATJapaneseAdministrationDataItemTest(TestCase):
         )
 
     def start_values(self, file_name):
+        install_start_api(self, file_name)
         for age in range(12, 37):
             # read csv, and split on "," the line
             csv_file = csv.reader(open(os.path.realpath(file_name), "r"), delimiter=",")
@@ -85,6 +91,7 @@ class CATJapaneseAdministrationDataItemTest(TestCase):
             self.assertContains(response, f"お子さまは次の単語を言いますか？「{word}」")
 
     def sequence_test(self, file_name):
+        install_sequence_api(self, file_name)
         response = self.client.get(self.url)
 
         contents = list(

--- a/webcdi/cdi_forms/cat_forms/tests/spanish.py
+++ b/webcdi/cdi_forms/cat_forms/tests/spanish.py
@@ -1,11 +1,10 @@
 import csv
 import datetime
 import os
-from unittest import skip
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.test import TestCase, tag
+from django.test import TestCase, override_settings, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -13,6 +12,10 @@ from cdi_forms.cat_forms.forms import CatItemForm
 from cdi_forms.models import BackgroundInfo
 from researcher_UI.models import Administration, Instrument, Study
 from researcher_UI.tests.utils import random_password
+from cdi_forms.cat_forms.tests.cat_api_mock import (
+    install_sequence_api,
+    install_start_api,
+)
 
 
 def csv_reader(utf8_data, dialect=csv.excel, **kwargs):
@@ -28,6 +31,7 @@ def make_boolean(text):
 
 
 @tag("cat")
+@override_settings(CAT_ENGINE="remote")
 class CATSpanishAdministrationDataItemTest(TestCase):
     fixtures = [
         "researcher_UI/fixtures/researcher_UI_test_fixtures.json",
@@ -69,6 +73,7 @@ class CATSpanishAdministrationDataItemTest(TestCase):
         )
 
     def start_values(self, file_name):
+        install_start_api(self, file_name)
         for age in range(12, 37):
             # read csv, and split on "," the line
             csv_file = csv.reader(open(os.path.realpath(file_name), "r"), delimiter=",")
@@ -86,6 +91,7 @@ class CATSpanishAdministrationDataItemTest(TestCase):
             self.assertContains(response, f"¿Su hijo/a dice ... {word}?")
 
     def sequence_test(self, file_name):
+        install_sequence_api(self, file_name)
         response = self.client.get(self.url)
 
         contents = list(
@@ -133,11 +139,6 @@ class CATSpanishAdministrationDataItemTest(TestCase):
             f"{settings.BASE_DIR}/cdi_forms/cat_forms/tests/test_data/spanish_start.csv"
         )
 
-    @skip(
-        "Recorded sequence predates the parameter set on the deployed CAT API "
-        "(live API now returns pre-rename item names like 'bolsa (household)'). "
-        "Re-record or replace with the offline jsCat validation harness."
-    )
     def test_spanish_seq_1(self):
         self.sequence_test(
             f"{settings.BASE_DIR}/cdi_forms/cat_forms/tests/test_data/spanish_sequence_1.csv"


### PR DESCRIPTION
Continues the stack (targets the security-round-2 branch; merge after #643). Addresses #628.

The five language CAT tests replayed a recorded item/response/theta sequence but reached the **live production R API** for each next item — so the suite needed a network connection and was coupled to whatever parameters are deployed. That coupling already broke the Spanish sequence test (deployed API drifted to pre-rename item names), which had been skipped.

- New `cat_api_mock` helper patches the view's `cdi_cat_api` to replay the recorded sequence (and answer `startItem` from the start-items CSV). The recording is the ground truth the API is meant to return, so this exercises the **full view flow** — render, store answer, advance, stop, persist theta — with no network.
- The live API rounded theta to 4 decimals; the mock matches so the `est_theta` assertions hold. Each class is pinned to `CAT_ENGINE=remote`.
- **Restores** the previously-skipped `test_spanish_seq_1`, and renames the Dutch class's copy-pasted `test_spanish_*` methods to `test_dutch_*`.

### Result
- CAT suite: **~13 min → ~15 s**, no network.
- Proven hermetic: the suite passes with `CAT_API_URL` pointed at a dead address (`127.0.0.1:1`) — a real call would fail connection-refused.
- 15 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)