### PR TITLE
11/11 Regression tests for the facelift/security/CKEditor/jQuery stack

### DIFF
--- a/webcdi/cdi_forms/cat_forms/tests/__init__.py
+++ b/webcdi/cdi_forms/cat_forms/tests/__init__.py
@@ -3,3 +3,4 @@ from .english import CATEnglishAdministrationDataItemTest  # noqa
 from .french import CATFrenchAdministrationDataItemTest  # noqa
 from .japanese import CATJapaneseAdministrationDataItemTest  # noqa
 from .spanish import CATSpanishAdministrationDataItemTest  # noqa
+from .browser_engine import BrowserCatTest, BrowserCatHardestEasiestTest  # noqa

--- a/webcdi/cdi_forms/cat_forms/tests/browser_engine.py
+++ b/webcdi/cdi_forms/cat_forms/tests/browser_engine.py
@@ -115,3 +115,69 @@ class BrowserCatTest(TestCase):
             if CatResponse.objects.filter(administration=self.administration).exists()
             else None
         )
+
+
+@tag("cat")
+@override_settings(CAT_ENGINE="browser")
+class BrowserCatHardestEasiestTest(TestCase):
+    """In browser mode the completion page's hardest/easiest word is computed
+    locally from the static bank instead of the R API. Verify the view reads
+    the right language bank, considers only 'yes' items, and applies the
+    easiness rule (max/min of the intercept, d = -a*b)."""
+
+    fixtures = [
+        "researcher_UI/fixtures/researcher_UI_test_fixtures.json",
+        "cdi_forms/fixtures/cdi_forms_test_fixtures.json",
+    ]
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="test_user", password="secret")
+        instrument = Instrument.objects.get(language="English", form="CAT")
+        self.study = Study.objects.create(
+            researcher=self.user, name="HE Study", instrument=instrument
+        )
+        self.administration = Administration.objects.create(
+            study=self.study,
+            subject_id=1,
+            repeat_num=1,
+            url_hash=random_password(size=64),
+            completed=True,
+            scored=True,
+            due_date=timezone.now() + datetime.timedelta(days=31),
+            completedBackgroundInfo=True,
+        )
+        BackgroundInfo.objects.create(administration=self.administration, age=24)
+        # a mix of yes/no; only the yes items should count
+        self.yes_indices = [35, 326, 206]  # ball, leg, find
+        self.no_index = 411  # answered "no", must be ignored
+        CatResponse.objects.create(
+            administration=self.administration,
+            administered_items=self.yes_indices + [self.no_index],
+            administered_words=["ball", "leg", "find", "pants"],
+            administered_responses=[True, True, True, False],
+            est_theta=0.5,
+        )
+
+    def _bank_expected(self):
+        from cdi_forms.cat_forms.views import _cat_bank
+
+        bank = {it["index"]: it for it in _cat_bank("EN")["items"]}
+        yes = [bank[i] for i in self.yes_indices]
+        easiness = lambda it: -it["a"] * it["b"]
+        return (min(yes, key=easiness)["definition"],  # hardest
+                max(yes, key=easiness)["definition"])  # easiest
+
+    def test_hardest_easiest_matches_bank(self):
+        from cdi_forms.cat_forms.views import AdministerAdministraionView
+
+        view = AdministerAdministraionView()
+        view.object = self.administration
+        view.language = "en"
+        hardest, easiest = view.get_hardest_easiest()
+
+        exp_hardest, exp_easiest = self._bank_expected()
+        self.assertEqual(hardest, exp_hardest)
+        self.assertEqual(easiest, exp_easiest)
+        # the "no" item must not be selected
+        self.assertNotEqual(hardest, "pants")
+        self.assertNotEqual(easiest, "pants")

--- a/webcdi/cdi_forms/tests/__init__.py
+++ b/webcdi/cdi_forms/tests/__init__.py
@@ -1,3 +1,4 @@
 from .tests_models import *  # noqa
 from .tests_process import *  # noqa
+from .tests_templatetags import *  # noqa
 from .tests_views import *  # noqa

--- a/webcdi/cdi_forms/tests/tests_templatetags/__init__.py
+++ b/webcdi/cdi_forms/tests/tests_templatetags/__init__.py
@@ -1,0 +1,1 @@
+from .sanitize import SanitizeRichtextTest  # noqa

--- a/webcdi/cdi_forms/tests/tests_templatetags/sanitize.py
+++ b/webcdi/cdi_forms/tests/tests_templatetags/sanitize.py
@@ -1,0 +1,63 @@
+from django.test import SimpleTestCase, tag
+
+from cdi_forms.templatetags.sanitize import sanitize_richtext
+
+
+@tag("sanitize")
+class SanitizeRichtextTest(SimpleTestCase):
+    """The study waiver / end-message fields are authored by researchers and
+    rendered into parents' browsers. sanitize_richtext is the control that
+    keeps stored content from injecting script — these tests lock that in so a
+    later refactor can't silently weaken it."""
+
+    def render(self, value):
+        return str(sanitize_richtext(value))
+
+    # --- formatting is preserved -------------------------------------------
+    def test_markdown_bold_and_links(self):
+        out = self.render("Please **consent**. See [details](https://x.org).")
+        self.assertIn("<strong>consent</strong>", out)
+        self.assertIn('href="https://x.org"', out)
+
+    def test_markdown_lists(self):
+        out = self.render("- one\n- two")
+        self.assertIn("<ul>", out)
+        self.assertIn("<li>one</li>", out)
+
+    def test_legacy_html_passes_through(self):
+        # content stored by the old rich-text editor is HTML, not Markdown
+        out = self.render("<p>Old <strong>editor</strong> content</p>")
+        self.assertIn("<strong>editor</strong>", out)
+        self.assertIn("Old", out)
+
+    def test_mailto_and_http_links_allowed(self):
+        self.assertIn("mailto:a@b.org", self.render("[mail](mailto:a@b.org)"))
+        self.assertIn("http://x.org", self.render("[x](http://x.org)"))
+
+    # --- dangerous content is stripped -------------------------------------
+    def test_script_tag_removed(self):
+        out = self.render("hello <script>alert(1)</script>")
+        self.assertNotIn("<script", out)
+
+    def test_event_handler_attribute_removed(self):
+        out = self.render('<p onclick="steal()">hi</p>')
+        self.assertNotIn("onclick", out)
+
+    def test_img_onerror_removed(self):
+        out = self.render('<img src="x" onerror="alert(1)">')
+        self.assertNotIn("onerror", out)
+
+    def test_javascript_protocol_link_removed(self):
+        out = self.render("[click](javascript:alert(1))")
+        self.assertNotIn("javascript:", out)
+
+    def test_iframe_and_style_removed(self):
+        out = self.render('<iframe src="evil"></iframe><style>x{}</style>ok')
+        self.assertNotIn("<iframe", out)
+        self.assertNotIn("<style", out)
+        self.assertIn("ok", out)
+
+    # --- edge cases --------------------------------------------------------
+    def test_empty_and_none(self):
+        self.assertEqual(self.render(""), "")
+        self.assertEqual(str(sanitize_richtext(None)), "")

--- a/webcdi/cdi_forms/tests/tests_views/__init__.py
+++ b/webcdi/cdi_forms/tests/tests_views/__init__.py
@@ -9,3 +9,4 @@ from .background_info_views import (  # noqa
 from .contact_views import AdministrationContactViewTest  # noqa
 from .instruction_views import InstructionDetailViewTest  # noqa
 from .pdf_detail_views import PDFAdministrationDetailViewTest  # noqa
+from .richtext_render import StudyRichTextRoundTripTest  # noqa

--- a/webcdi/cdi_forms/tests/tests_views/richtext_render.py
+++ b/webcdi/cdi_forms/tests/tests_views/richtext_render.py
@@ -1,0 +1,58 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, tag
+from django.urls import reverse
+from django.utils import timezone
+
+from researcher_UI.models import Administration, Instrument, Study
+from researcher_UI.tests import generate_fake_results
+
+MARKDOWN_WITH_SCRIPT = "**Thank you** for [helping](https://x.org).<script>steal()</script>"
+
+
+@tag("richtext")
+class StudyRichTextRoundTripTest(TestCase):
+    """End-to-end for the CKEditor -> Markdown change: a researcher-authored
+    waiver / end message is stored verbatim (plain TextField, no editor
+    mangling) and rendered to participants through the Markdown+bleach
+    sanitizer — formatted, with the script stripped."""
+
+    fixtures = [
+        "researcher_UI/fixtures/researcher_UI_test_fixtures.json",
+        "cdi_forms/fixtures/cdi_forms_test_fixtures.json",
+    ]
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="researcher", password="secret")
+        instrument = Instrument.objects.get(language="English", form="WS")
+        self.study = Study.objects.create(
+            researcher=self.user,
+            name="RichText Study",
+            instrument=instrument,
+            waiver=MARKDOWN_WITH_SCRIPT,
+            end_message="bespoke",
+            end_message_text=MARKDOWN_WITH_SCRIPT,
+        )
+
+    def test_field_stores_markdown_verbatim(self):
+        # the field is a plain TextField now; nothing rewrites the content
+        study = Study.objects.get(pk=self.study.pk)
+        self.assertEqual(study.waiver, MARKDOWN_WITH_SCRIPT)
+        self.assertEqual(study.end_message_text, MARKDOWN_WITH_SCRIPT)
+
+    def test_end_message_renders_sanitized_to_participant(self):
+        generate_fake_results(self.study, 1)
+        administration = Administration.objects.filter(
+            study=self.study, completed=True
+        )[0]
+        response = self.client.get(
+            reverse(
+                "administration_summary_view",
+                kwargs={"hash_id": administration.url_hash},
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+        # Markdown was rendered ...
+        self.assertContains(response, "<strong>Thank you</strong>")
+        self.assertContains(response, 'href="https://x.org"')
+        # ... and the script was stripped
+        self.assertNotContains(response, "<script>steal")

--- a/webcdi/webcdi/tests/__init__.py
+++ b/webcdi/webcdi/tests/__init__.py
@@ -3,3 +3,4 @@ from .test_management_commands import *  # noqa
 from .test_urls import *  # noqa
 from .test_views import *  # noqa
 from .tests_api import *  # noqa
+from .test_settings import EnvParsingTest  # noqa

--- a/webcdi/webcdi/tests/test_settings.py
+++ b/webcdi/webcdi/tests/test_settings.py
@@ -1,0 +1,48 @@
+from django.test import SimpleTestCase, tag
+
+from webcdi.settings import _parse_env_admins, _parse_env_list
+from webcdi.utils import is_true
+
+
+@tag("settings")
+class EnvParsingTest(SimpleTestCase):
+    """The settings env-var parsers and DEBUG coercion are load-bearing for
+    deploy; the refactor that introduced them was verified by a manual dump
+    diff, so lock the behavior in here."""
+
+    def test_parse_env_list_unquoted_shorthand(self):
+        self.assertEqual(
+            _parse_env_list("[localhost,127.0.0.1,web]"),
+            ["localhost", "127.0.0.1", "web"],
+        )
+
+    def test_parse_env_list_quoted_literal(self):
+        self.assertEqual(_parse_env_list('["localhost", "web"]'), ["localhost", "web"])
+
+    def test_parse_env_admins_unquoted_shorthand(self):
+        # shorthand strips whitespace, including inside names
+        self.assertEqual(
+            _parse_env_admins("[(Local Admin,a@b.com)]"),
+            [("LocalAdmin", "a@b.com")],
+        )
+
+    def test_parse_env_admins_quoted_literal(self):
+        self.assertEqual(
+            _parse_env_admins('[("Local Admin", "a@b.com")]'),
+            [("Local Admin", "a@b.com")],
+        )
+
+    def test_is_true_truthy_strings(self):
+        self.assertTrue(is_true("true"))
+        self.assertTrue(is_true("True"))
+        self.assertTrue(is_true(True))
+        self.assertTrue(is_true(1))
+
+    def test_is_true_falsey_strings(self):
+        # the bug this fixed: bool("False") is True, so DEBUG=False used to
+        # enable debug; is_true("False") must be False
+        self.assertFalse(is_true("False"))
+        self.assertFalse(is_true("false"))
+        self.assertFalse(is_true(""))
+        self.assertFalse(is_true(False))
+        self.assertFalse(is_true(0))

--- a/webcdi/webcdi/tests/test_urls/__init__.py
+++ b/webcdi/webcdi/tests/test_urls/__init__.py
@@ -1,1 +1,2 @@
 from .test_webcdi_urls import *  # noqa
+from .page_smoke import ConsolePageSmokeTest  # noqa

--- a/webcdi/webcdi/tests/test_urls/page_smoke.py
+++ b/webcdi/webcdi/tests/test_urls/page_smoke.py
@@ -1,0 +1,64 @@
+from django.contrib.auth.models import User
+from django.test import TestCase, tag
+from django.urls import reverse
+
+from researcher_UI.models import Instrument, Study
+
+
+@tag("url", "smoke")
+class ConsolePageSmokeTest(TestCase):
+    """Every researcher-facing page renders (200) with a content marker.
+
+    The facelift rewrote the console templates (nav, footer, dashboard, study
+    detail, toolbars, profile, instruments); these are the broad net that
+    catches a template regression — missing {% load %}, bad {% url %},
+    absent context variable — without needing a browser."""
+
+    fixtures = [
+        "researcher_UI/fixtures/researcher_UI_test_fixtures.json",
+        "cdi_forms/fixtures/cdi_forms_test_fixtures.json",
+    ]
+
+    def setUp(self):
+        # creating a User auto-creates its Researcher (post_save signal)
+        self.user = User.objects.create_user(username="researcher", password="secret")
+        self.client.force_login(self.user)
+        instrument = Instrument.objects.filter(language="English", form="WS")[0]
+        self.study = Study.objects.create(
+            researcher=self.user,
+            instrument=instrument,
+            min_age=instrument.min_age,
+            max_age=instrument.max_age,
+            name="Smoke Study",
+        )
+
+    def assert_ok(self, url, marker=None):
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200, f"{url} -> {response.status_code}")
+        if marker:
+            self.assertContains(response, marker)
+
+    def test_dashboard(self):
+        # empty-vs-grid state both render; the grid path exercises the counts
+        self.assert_ok(reverse("researcher_ui:console"), "administration group")
+
+    def test_study_detail(self):
+        self.assert_ok(
+            reverse("researcher_ui:console_study", kwargs={"pk": self.study.pk}),
+            self.study.name,
+        )
+
+    def test_add_study(self):
+        self.assert_ok(reverse("researcher_ui:add_study"))
+
+    def test_profile(self):
+        self.assert_ok(reverse("researcher_ui:profile"), "profile")
+
+    def test_instruments(self):
+        self.assert_ok(
+            reverse(
+                "researcher_ui:researcher_add_instruments",
+                kwargs={"pk": self.user.researcher.pk},
+            ),
+            "instruments",
+        )

--- a/webcdi/webcdi/tests/test_urls/test_webcdi_urls.py
+++ b/webcdi/webcdi/tests/test_urls/test_webcdi_urls.py
@@ -29,3 +29,20 @@ class TestWebCDIUrls(TestCase):
 
         resolver = resolve(reverse("django_registration_register"))
         self.assertEqual(resolver.func.view_class, CustomRegistrationView)
+
+    def test_webcdi_about_url(self):
+        # About page added in the facelift; content markers guard the template
+        response = self.client.get(reverse("about"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "About Web-CDI")
+        self.assertContains(response, "Wordbank")
+
+    def test_webcdi_documentation_url(self):
+        response = self.client.get(reverse("documentation"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "documentation")
+
+    def test_health_endpoint_ok(self):
+        # EB load-balancer probe; must not 500 (it did before the fix)
+        response = self.client.get("/health/")
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Final PR of the stack (targets the CAT-tests branch; merge last). Adds fast, network-free coverage around the parts of the stack we changed and verified by hand.

### Tier 1 — the "changed it but nothing tested it" holes
- **`sanitize_richtext` (10 tests)** — locks in the XSS control: `<script>`, `onclick`, `javascript:`, `onerror`, `iframe`/`style` stripped; Markdown, legacy HTML, and mailto/http links preserved. It's a **security filter that had no test**.
- **Page-render smoke** — About, Documentation, `/health/` (public) + an authenticated pass over dashboard, study detail, add-study, profile, instruments. The broad net for the ~20 templates the facelift touched (About/Documentation had **no** test).
- **Env parsing (6 tests)** — `_parse_env_list` / `_parse_env_admins` and `is_true`, incl. the `DEBUG=False` bug (`bool("False")` is `True`) the refactor fixed.

### Tier 2
- **Study rich-text round-trip** — waiver/end-message stored verbatim in the new `TextField`, rendered to participants Markdown-formatted **and** sanitized (ties the CKEditor removal end to end).
- **CAT browser-mode hardest/easiest** — the local bank computation that replaced the R call selects from `yes` items by the easiness rule.

### Also: a discovery-gap fix
`cat_forms/tests/__init__.py` never imported `browser_engine`, so the jsCat browser-CAT tests (added in #622) **were never in the default suite** — they only ran when invoked by explicit path. Now wired in. Discovery here is by `__init__` re-export (files aren't named `test_*.py`), so each new module must be registered there — worth knowing as a footgun.

### Verification
Full no-label suite: **255 tests OK** (up from 222 — new tests + the now-discovered browser-CAT tests), all seven new markers confirmed present in the run. Tier 3 (making the excluded Selenium suite actually run — the real guard for the jQuery migration) remains, best folded into CI/CD (#639).

🤖 Generated with [Claude Code](https://claude.com/claude-code)