### PR TITLE
Dutch group feedback: submit-button wording, MB-CDI link in new tab, no-location background variant

### DIFF
--- a/webcdi/cdi_forms/form_data/background_info/Dutch_CAT_no_location.json
+++ b/webcdi/cdi_forms/form_data/background_info/Dutch_CAT_no_location.json
@@ -1,0 +1,34 @@
+[
+    {
+        "page":"front",
+        "contents":[
+            {
+                "fieldset":"Algemene vragen",
+                "fields":[
+                    {
+                        "field":"form_filler",
+                        "div":[
+                            "form_filler_other"
+                        ]
+                    },
+                    {
+                        "field":"child_dob"
+                    },
+                    {
+                        "field":"age"
+                    },
+                    {
+                        "field":"sex"
+                    },
+                    {
+                        "field":"mother_yob_confirmation"
+                    },
+                    {
+                        "field":"birth_weight_confirmation_lb",
+                        "widget_type":"Select"
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/webcdi/cdi_forms/templates/cdi_forms/administration_summary.html
+++ b/webcdi/cdi_forms/templates/cdi_forms/administration_summary.html
@@ -240,7 +240,7 @@
                 {% if object.study.custom_redirect_button_boolean %}
                     {{ object.study.custom_redirect_button_text }}
                 {% else %}
-                    {% trans "Click to complete the study" %} 
+                    {% trans "Submit your responses" %}
                 {% endif %}
                 </a></h4>
         </div>

--- a/webcdi/cdi_forms/templates/cdi_forms/background_info.html
+++ b/webcdi/cdi_forms/templates/cdi_forms/background_info.html
@@ -52,7 +52,7 @@
         </ul>
     </div>
     <p>
-        {% trans "For more information about the MB-CDI," %} <a href="http://mb-cdi.stanford.edu/">{% trans "click here" %}</a>.<br> 
+        {% trans "For more information about the MB-CDI," %} <a href="http://mb-cdi.stanford.edu/" target="_blank" rel="noopener">{% trans "click here" %}</a>.<br> 
         {% trans "Thank you! We appreciate your time and effort!" %}
     </p>
 </div>

--- a/webcdi/cdi_forms/templates/cdi_forms/cat_forms/cat_completed.html
+++ b/webcdi/cdi_forms/templates/cdi_forms/cat_forms/cat_completed.html
@@ -49,7 +49,7 @@
 
         {% if object.study.redirect_boolean %}
         <div class="row justify-content-center">
-            <h4><a class="btn btn-danger btn-lg active" href="{{ object.redirect_url }}">{% trans "Click to complete the study" %}</a></h4>
+            <h4><a class="btn btn-danger btn-lg active" href="{{ object.redirect_url }}">{% trans "Submit your responses" %}</a></h4>
         </div>
         {% endif %}
 

--- a/webcdi/cdi_forms/templates/cdi_forms/study_group.html
+++ b/webcdi/cdi_forms/templates/cdi_forms/study_group.html
@@ -26,7 +26,7 @@
                 </ul>
             </div>
             <p>
-                {% trans "For more information about the MB-CDI," %} <a href="http://mb-cdi.stanford.edu/">{% trans "click here" %}</a>.<br> 
+                {% trans "For more information about the MB-CDI," %} <a href="http://mb-cdi.stanford.edu/" target="_blank" rel="noopener">{% trans "click here" %}</a>.<br>
                 {% trans "Thank you! We appreciate your time and effort!" %}
             </p>
         </div>

--- a/webcdi/researcher_UI/fixtures/dutch_cat_no_location_demographic.json
+++ b/webcdi/researcher_UI/fixtures/dutch_cat_no_location_demographic.json
@@ -1,0 +1,10 @@
+[
+    {
+        "model": "researcher_UI.demographic",
+        "pk": null,
+        "fields": {
+            "name": "Dutch_CAT_no_location.json",
+            "path": "/form_data/background_info/Dutch_CAT_no_location.json"
+        }
+    }
+]


### PR DESCRIPTION
Three small, independent fixes from the Dutch group's feedback (they run their own EU deployment). Branched off `master`, so it's independent of the modernization stack and can merge on its own.

### 1. Completion button wording
"Click to complete the study" → **"Submit your responses"** (`administration_summary.html`, `cat_forms/cat_completed.html`). Their participants continue the study in Qualtrics afterward, and the old wording read like the end — some were closing the tab.

Translation note: only **fr** and **ja** had translated the old string; every other locale (including **nl**) had an empty `msgstr` and already showed the English text, so the Dutch group sees the new wording immediately. A `makemessages` pass + fr/ja re-translation is the only follow-up; I didn't hand-edit those translations.

### 2. MB-CDI link opens in a new tab
Added `target="_blank" rel="noopener"` to the "For more information about the MB-CDI" link on the study-intro (`study_group.html`) and **`background_info.html`** pages. The latter is exactly the scenario they described — a participant mid-questionnaire clicks the link and loses their place.

### 3. Background questionnaire without Land/Postcode
New **`Dutch_CAT_no_location.json`** — a copy of `Dutch_CAT.json` with the `country` (Land) + `zip_code` (postcode) block removed. Postcode is sensitive personal data, especially under GDPR on an EU server.

To enable it: load `researcher_UI/fixtures/dutch_cat_no_location_demographic.json` (`manage.py loaddata dutch_cat_no_location_demographic`), or add a `Demographic` record in the admin (name `Dutch_CAT_no_location.json`, path `/form_data/background_info/Dutch_CAT_no_location.json`) — same as their existing `Dutch_CAT` option. It then appears as a selectable questionnaire when creating a study, leaving the original intact.

### Two feedback items are already fixed elsewhere (not in this PR)
- **CAT reloads the whole page per question** → fixed by the in-browser jsCat engine (the new CAT engine swaps only the question text). Comes with the modernization stack; needs `CAT_ENGINE=browser` on deploy.
- **"Zeg ba" → "Zeg bal" instruction-image typo** → the current repo images already read `Zeg "bal"` / `Say "ball"` (verified the base, CAT, and WS variants). Their EU server just has an older image.

Both resolve when the Dutch server updates to the current version.

### Verification
Trivial text/attribute edits + validated JSON. Full participant-flow browser rendering (these pages need a live administration) was disproportionate; the two changes are `{% trans %}` string swaps and HTML attribute additions, which can't introduce template errors, and both new JSON files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)