### PR TITLE
Restore the CAT progress counter (clipped by the facelift's thin bar)

### DIFF
--- a/webcdi/cdi_forms/templates/cdi_forms/cat_forms/cat_form.html
+++ b/webcdi/cdi_forms/templates/cdi_forms/cat_forms/cat_form.html
@@ -10,16 +10,13 @@
         position: relative;
       }
       
+      /* The counter sits on its own line below the (now thin) progress bar.
+         It used to be absolutely overlaid on the bar, but the restyled bar is
+         only 10px tall with overflow:hidden, which clipped the text away. */
       .progress-bar-title {
-        position: absolute;
         text-align: center;
-        line-height: 20px; /* line-height should be equal to bar height */
-        overflow: hidden;
         color: #000;
-        margin-top: 10px;
-        right: 0;
-        left: 0;
-        top: 0;
+        margin-top: 6px;
       }
 </style>
 {% endblock %}
@@ -49,9 +46,9 @@
     <div class="container">
         <div class="row pt10vh">
             <div class="progress" style="width:100%">
-                <div class="progress-bar" role="progressbar" aria-valuenow="{{ words_shown|div:max_words }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ words_shown|div:max_words }}%"></div>                   
-                <div class="progress-bar-title">{% blocktrans context "cat"%}{{ words_shown }} of {{ max_words }} (maximum) {% endblocktrans %}</div>
-            </div> 
+                <div class="progress-bar" role="progressbar" aria-valuenow="{{ words_shown|div:max_words }}" aria-valuemin="0" aria-valuemax="100" style="width:{{ words_shown|div:max_words }}%"></div>
+            </div>
+            <div class="progress-bar-title" style="width:100%">{% blocktrans context "cat"%}{{ words_shown }} of {{ max_words }} (maximum) {% endblocktrans %}</div>
         </div>
         <div class="row pt10vh">
             <div class="col-12 center">

--- a/webcdi/cdi_forms/templates/cdi_forms/cat_forms/cat_form_browser.html
+++ b/webcdi/cdi_forms/templates/cdi_forms/cat_forms/cat_form_browser.html
@@ -9,16 +9,13 @@
         position: relative;
       }
 
+      /* The counter sits on its own line below the (now thin) progress bar.
+         It used to be absolutely overlaid on the bar, but the restyled bar is
+         only 10px tall with overflow:hidden, which clipped the text away. */
       .progress-bar-title {
-        position: absolute;
         text-align: center;
-        line-height: 20px; /* line-height should be equal to bar height */
-        overflow: hidden;
         color: #000;
-        margin-top: 10px;
-        right: 0;
-        left: 0;
-        top: 0;
+        margin-top: 6px;
       }
 </style>
 {% endblock %}
@@ -45,8 +42,8 @@
         <div class="row pt10vh">
             <div class="progress" style="width:100%">
                 <div id="cat_progress_bar" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width:0%"></div>
-                <div class="progress-bar-title"><span id="cat_progress_label"></span></div>
             </div>
+            <div class="progress-bar-title" style="width:100%"><span id="cat_progress_label"></span></div>
         </div>
         <div class="row pt10vh">
             <div class="col-12 center">


### PR DESCRIPTION
Stacked on top of the stack (base `phase11-ci`) since the jsCat PR isn't merged yet — it needs both the facelift (which introduced the thin progress bar) and the jsCat CAT templates.

### The bug
Henry noticed the CAT progress-bar counter (the "N of MAX (maximum)" text the French CAT group asked for) had disappeared. It wasn't removed — it was **clipped invisible**. The facelift restyled `.progress` to a thin 10px bar with `overflow:hidden`, but the counter (`.progress-bar-title`) was absolutely positioned *inside* that bar, assuming the old ~20px height. The restyled bar clips it away. The number was still being computed correctly the whole time (`"1 of 50 (maximum)"`), just invisible.

### The fix
Move the counter onto its own centered line just below the bar, in both CAT templates:
- `cat_form.html` (remote engine)
- `cat_form_browser.html` (in-browser jsCat engine)

Dropped the absolute positioning / `overflow:hidden` / bar-height assumptions; it's now a normal centered line under the thin bar.

### Verification
Rendered the browser-engine CAT locally: the counter shows **"1 of 50 (maximum)"** below the bar and increments correctly (answering advanced it to "2 of 50", bar → 4%). Both engines share the identical fix.

### Merge note
The two files here also live in the jsCat PR (#622). Whichever way the stack lands, keep this version (counter below the bar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)