### PR TITLE
Round 2 (B): study-group page redesign — one verb per action, scoped download, status badge, pinned columns

### DIFF
--- a/webcdi/cdi_forms/static/cdi_forms/webcdi-theme.css
+++ b/webcdi/cdi_forms/static/cdi_forms/webcdi-theme.css
@@ -735,3 +735,206 @@ hr {
   color: var(--wcdi-ink-soft);
 }
 .wcdi-ref a { word-break: break-all; }
+
+/* ---- study-group page: selection toolbar, table, dialogs (round-2 redesign) ---- */
+.wcdi-table-scroll {
+  overflow-x: auto;
+  max-width: 100%;
+}
+.wcdi-admin-table {
+  margin-bottom: 0;
+  border-collapse: separate; /* needed for sticky cells to keep their borders */
+  border-spacing: 0;
+}
+.wcdi-admin-table thead th {
+  white-space: nowrap;
+  background: var(--wcdi-card);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+.wcdi-admin-table td {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  background: var(--wcdi-card);
+}
+.wcdi-admin-table tbody tr:hover td {
+  background: var(--wcdi-primary-wash);
+}
+/* pinned identity columns: select, edit, participant ID */
+.wcdi-admin-table .wcdi-col-select_col,
+.wcdi-admin-table .wcdi-col-edit,
+.wcdi-admin-table .wcdi-col-subject_id {
+  position: sticky;
+  z-index: 1;
+}
+.wcdi-admin-table thead .wcdi-col-select_col,
+.wcdi-admin-table thead .wcdi-col-edit,
+.wcdi-admin-table thead .wcdi-col-subject_id {
+  z-index: 3;
+}
+.wcdi-admin-table .wcdi-col-select_col { left: 0; width: 36px; }
+.wcdi-admin-table .wcdi-col-edit { left: 36px; width: 76px; }
+.wcdi-admin-table .wcdi-col-subject_id { left: 112px; font-weight: 600; }
+.wcdi-admin-table .wcdi-col-subject_id::after {
+  /* soft edge that appears when the table scrolls under the pinned columns */
+  content: "";
+  position: absolute;
+  top: 0; right: -1px; bottom: 0;
+  width: 1px;
+  background: var(--wcdi-line);
+}
+.wcdi-admin-table .wcdi-col-repeat_num { text-align: center; }
+
+.wcdi-row-edit {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid var(--wcdi-line);
+  background: var(--wcdi-card);
+  color: var(--wcdi-primary);
+  font-size: 12.5px;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 3px 8px;
+  cursor: pointer;
+  line-height: 1.3;
+}
+.wcdi-row-edit:hover {
+  border-color: var(--wcdi-primary);
+  background: var(--wcdi-primary-wash);
+}
+.wcdi-link-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.wcdi-copy-link {
+  border: 1px solid var(--wcdi-line);
+  background: var(--wcdi-card);
+  color: var(--wcdi-ink-soft);
+  border-radius: 6px;
+  width: 26px;
+  height: 24px;
+  cursor: pointer;
+  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.wcdi-copy-link:hover { color: var(--wcdi-primary); border-color: var(--wcdi-primary); }
+.wcdi-copy-link.copied { color: var(--wcdi-check); border-color: var(--wcdi-check); }
+
+.wcdi-badge {
+  display: inline-block;
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 2px 9px;
+  border-radius: 999px;
+  white-space: nowrap;
+  line-height: 1.5;
+}
+.wcdi-badge-scored   { background: var(--wcdi-primary-wash); color: var(--wcdi-primary); }
+.wcdi-badge-done     { background: var(--wcdi-check-wash);   color: var(--wcdi-check); }
+.wcdi-badge-survey   { background: #fbf1e2; color: #8a5a14; }
+.wcdi-badge-progress { background: #fbf1e2; color: #8a5a14; }
+.wcdi-badge-new      { background: #eef1f4; color: var(--wcdi-ink-soft); }
+.wcdi-badge-expired  { background: #fbeaea; color: #a33a3a; }
+.wcdi-badge-inactive { background: #eef1f4; color: var(--wcdi-ink-soft); text-decoration: line-through; }
+.wcdi-chip {
+  display: inline-block;
+  font-size: 10.5px;
+  color: var(--wcdi-ink-soft);
+  border: 1px solid var(--wcdi-line);
+  border-radius: 4px;
+  padding: 0 5px;
+  margin-left: 6px;
+  vertical-align: 1px;
+}
+.wcdi-table-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 8px;
+}
+.wcdi-table-foot nav { margin: 0; }
+.wcdi-table-foot .pagination { margin: 0; }
+
+.wcdi-edit-meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 14px;
+  font-size: 13px;
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--wcdi-line);
+}
+.wcdi-edit-meta dt { color: var(--wcdi-ink-soft); font-weight: 500; }
+.wcdi-edit-meta dd { margin: 0; }
+
+/* download menu: scope header + disabled-with-reason items */
+.wcdi-download-menu { min-width: 320px; }
+.wcdi-download-menu .dropdown-header {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--wcdi-ink-soft);
+}
+.wcdi-download-menu .wcdi-scope-selected { color: var(--wcdi-primary); }
+.wcdi-download-menu .dropdown-item.disabled,
+.wcdi-download-menu .dropdown-item:disabled { color: var(--wcdi-ink-soft); opacity: 0.75; cursor: default; }
+.wcdi-needs-hint { font-size: 11.5px; color: var(--wcdi-ink-soft); }
+
+.wcdi-selection-label { white-space: nowrap; }
+.wcdi-danger-text { color: #a33a3a; }
+.wcdi-btn-danger-solid, .wcdi-btn-danger-solid:focus {
+  background: #a33a3a;
+  border-color: #a33a3a;
+  color: #fff;
+  font-weight: 600;
+}
+.wcdi-btn-danger-solid:hover:not(:disabled) { background: #8a2f2f; border-color: #8a2f2f; color: #fff; }
+.wcdi-btn-danger-solid:disabled { opacity: 0.5; background: #a33a3a; border-color: #a33a3a; color: #fff; }
+
+/* danger zone (group settings page) */
+.wcdi-danger-zone {
+  border: 1px solid #d9a3a3;
+  border-radius: var(--wcdi-radius);
+  background: var(--wcdi-card);
+  padding: 14px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 28px;
+}
+.wcdi-danger-zone h2 { color: #a33a3a; font-size: 16px; margin: 0 0 2px; }
+.wcdi-danger-zone p { margin: 0; font-size: 13.5px; color: var(--wcdi-ink-soft); max-width: 56ch; }
+
+/* add-administrations dialog: method tabs */
+.wcdi-method-pills { gap: 6px; margin-bottom: 14px; }
+.wcdi-method-pills .nav-link {
+  font-size: 13.5px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--wcdi-line);
+  color: var(--wcdi-ink);
+  background: var(--wcdi-paper);
+}
+.wcdi-method-pills .nav-link.active {
+  background: var(--wcdi-primary);
+  border-color: var(--wcdi-primary);
+  color: #fff;
+  font-weight: 600;
+}
+.wcdi-method-pills .wcdi-method-pill-sep { margin-left: auto; }
+.wcdi-method-pills .wcdi-method-pill-sep .nav-link:not(.active) { border-style: dashed; color: var(--wcdi-ink-soft); }
+.wcdi-method-panels { min-height: 120px; }
+.wcdi-method-help { font-size: 14px; color: var(--wcdi-ink-soft); margin: 0 0 10px; }
+.wcdi-method-label { font-size: 13px; font-weight: 600; margin-bottom: 4px; display: block; }
+.wcdi-link-row { display: flex; gap: 8px; align-items: center; }
+.wcdi-link-row input { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; }

--- a/webcdi/researcher_UI/tables.py
+++ b/webcdi/researcher_UI/tables.py
@@ -1,58 +1,124 @@
 import django_tables2 as tables
-from django.utils.html import mark_safe
+from django.utils import timezone
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
 from researcher_UI.models import Administration
 
 
-# Table for organizing administration objects into a table on the researcher interface
+# Table for organizing administration objects into a table on the researcher interface.
+#
+# Ten columns: select, edit, participant ID, lab ID, admin #, link, status,
+# created, expires, completed. The five completion booleans are folded into one
+# Status badge (see render_status); the rarely-needed fields (last modified,
+# confirmed-completion, completion-flag response, opt-out) live in the row's
+# Edit dialog (table.html) or appear as a chip next to the status.
 class StudyAdministrationTable(tables.Table):
-    # select_col = tables.columns.CheckBoxColumn(accessor='id') # Creates a column of checkboxes associated with each administration ID
     select_col = tables.CheckBoxColumn(
-        accessor="pk", attrs={"th__input": {"onclick": "toggle(this)"}}, orderable=False
-    )
-    subject_id = tables.TemplateColumn(
-        '<span href="/interface/edit-administration/{{ record.pk }}/">{{ record.subject_id }}</span>'
-    )  # Generate Link to edit subject_id
-    local_lab_id = tables.TemplateColumn(
-        '<span href="/interface/edit-local-lab-id/{{ record.pk }}/">{{ record.local_lab_id }}</span>'
-    )  # Generate Link to edit local_lab_id
-    link = tables.TemplateColumn(
-        '<a href="{{ record.get_absolute_url }}" target="_blank">link</a>',
+        accessor="pk",
+        attrs={"th__input": {"onclick": "toggle(this)"}},
         orderable=False,
-    )  # Generates a column of administration links in each row
-    analysis = tables.Column(orderable=True, order_by=["analysis", "pk"])
-    opt_out = tables.TemplateColumn(
-        '<span href="/interface/edit-opt-out/{{ record.pk }}/">{{ record.opt_out }}</span>'
     )
+    # Opens the per-row edit dialog defined in table.html
+    edit = tables.TemplateColumn(
+        '<button type="button" class="wcdi-row-edit" onclick="edit_function({{ record.pk }})" '
+        'title="Edit administration {{ record.subject_id }}">'
+        '<i class="fa fa-pencil" aria-hidden="true"></i><span>Edit</span></button>',
+        orderable=False,
+        verbose_name="",
+        empty_values=(),
+    )
+    subject_id = tables.Column(verbose_name="Participant ID")
+    local_lab_id = tables.Column(verbose_name="Lab ID", default="—")
+    repeat_num = tables.Column(verbose_name="Admin #")
+    link = tables.TemplateColumn(
+        '<span class="wcdi-link-cell">'
+        '<a href="{{ record.get_absolute_url }}" target="_blank" rel="noopener" title="Open the participant\'s link in a new tab">Open</a>'
+        '<button type="button" class="wcdi-copy-link" data-link="{{ record.get_absolute_url }}" '
+        'title="Copy the participant\'s link"><i class="fa fa-clone" aria-hidden="true"></i><span class="sr-only">Copy link</span></button>'
+        "</span>",
+        orderable=False,
+        verbose_name="Link",
+    )
+    status = tables.Column(
+        empty_values=(),
+        orderable=True,
+        order_by=("scored", "completed", "completedSurvey", "completedBackgroundInfo", "pk"),
+    )
+    created_date = tables.DateTimeColumn(verbose_name="Created")
+    due_date = tables.DateTimeColumn(verbose_name="Expires")
+    completed_date = tables.DateTimeColumn(verbose_name="Completed")
+    # Only shown for studies that confirm age/completion (get_helper excludes it otherwise)
+    analysis = tables.Column(
+        verbose_name="Confirmed", orderable=True, order_by=["analysis", "pk"]
+    )
+
+    def render_status(self, record):
+        now = timezone.now()
+        if not record.is_active:
+            kind, label, tip = "inactive", "Inactive", "Deactivated by an administrator"
+        elif record.scored:
+            kind, label, tip = "scored", "Scored", "Completed and scored; ready to download"
+        elif record.completed:
+            kind, label, tip = "done", "Completed", "Completed; scores are computed overnight"
+        elif record.completedSurvey:
+            kind, label, tip = "survey", "Survey pending", "CDI completed; the follow-up questions are still open"
+        elif record.due_date and record.due_date < now:
+            kind, label, tip = "expired", "Expired", "The link expired before the form was completed"
+        elif record.completedBackgroundInfo:
+            kind, label, tip = "progress", "In progress", "Background info completed; CDI in progress"
+        else:
+            kind, label, tip = "new", "Not started", "The link has not been used yet"
+        if record.last_modified:
+            tip += " · last activity " + timezone.localtime(record.last_modified).strftime("%-m/%-d/%Y %-I:%M %p")
+        chip = ""
+        if record.opt_out:
+            chip = '<span class="wcdi-chip" title="Participant opted out of broader data sharing">opt-out</span>'
+        return format_html(
+            '<span class="wcdi-badge wcdi-badge-{}" title="{}">{}</span>{}',
+            kind, tip, label, mark_safe(chip),
+        )
+
+    def _render_when(self, value):
+        # ISO in a data attribute; table.html converts to the viewer's local time
+        if not value:
+            return mark_safe('<span class="wcdi-muted">—</span>')
+        return format_html(
+            '<time data-utc="{}">{}</time>', value.isoformat(), value.strftime("%-m/%-d/%y")
+        )
+
+    def render_created_date(self, value):
+        return self._render_when(value)
+
+    def render_due_date(self, value):
+        return self._render_when(value)
+
+    def render_completed_date(self, value):
+        return self._render_when(value)
 
     def render_analysis(self, value):
         return (
             mark_safe('<span class="true">✔</span>')
             if value
-            else mark_safe('<span class="false">✘</span>') if not value else ""
+            else mark_safe('<span class="false">✘</span>')
         )
-
-    def __init__(self, *args, **kwargs):  
-        super().__init__(*args, **kwargs)
-        self.base_columns['subject_id'].verbose_name = "Participant Id"
-        self.base_columns['opt_out'].verbose_name = "Opted out of sharing"
 
     # Associates administration table with administration model
     class Meta:
         model = Administration
-        exclude = (
-            "study",
-            "id",
-            "url_hash",
-            "page_number",
-            "bypass",
-            "include",
-        )  # Excludes some fields in administration objects from table
-        sequence = (
+        fields = (
             "select_col",
+            "edit",
             "subject_id",
             "local_lab_id",
             "repeat_num",
             "link",
-        )  # Specifies column order within table
+            "status",
+            "created_date",
+            "due_date",
+            "completed_date",
+            "analysis",
+        )
+        sequence = fields
+        attrs = {"class": "table wcdi-admin-table"}
+        row_attrs = {"data-pk": lambda record: record.pk}

--- a/webcdi/researcher_UI/templates/researcher_UI/administer_new_modal.html
+++ b/webcdi/researcher_UI/templates/researcher_UI/administer_new_modal.html
@@ -1,130 +1,148 @@
-<!-- Modal window for creating new tests within a study -->
+<!-- Add-administrations dialog. One method visible at a time (tabs); the
+     backend (admin_new_fun) decides what was asked for by which fields arrive,
+     so the hidden tabs' empty fields change nothing. -->
 
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
+        <h4 id="modal-title" class="modal-title">Add administrations</h4>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 id="modal-title" class="modal-title" >Administer new administrations</h4>
       </div>
       <div class="modal-body">
-      <form method='post' class="form-horizontal" enctype="multipart/form-data">
+      <form method='post' enctype="multipart/form-data" id="add-administrations-form">
         {% csrf_token %}
-        <p style="font-size:large">
-          Use ONE of these options to add participants to your interface. 
-          Use the "Your Own Participant ID(s)" option to create links using your own ID numbers (numeric only). 
-          Typically, this is done in small batches when you are ready to send out the links. Use the "Upload a CSV of ID(s)" or "Autogenerate Web-CDI ID(s)" options if you want to create many links at the same time. 
-          Use the “Single Reusable Link” option if you are collecting data anonymously (e.g., via Facebook, Prolific) - anyone who clicks on the link will create a new administration using a Web-CDI ID. 
-          Note that all links will expire in the time (default = 14 days) from their creation.</p>
-        <hr />
-        <div class="row form-group">
-          <div class="col-12">
-            <label for="new-subject-ids" class="control-label" style="text-weight:bold; font-size:larger">
-              Your Own Participant ID(s):
-            </label>               
-            <p>Use this option to add administrations using your own ID numbers (numeric only). Typically, this is done in small batches when you are ready to send out the links. If you enter an ID for a participant who has already had an administration in this Administration Group, Web-CDI will assume it is the same child. IDs should not include any identifiable information and are forced to be numeric. All links will expire in the time (default = 14 days) from their creation.</p>
-            <textarea name="new_subject_ids" class="form-control" rows="3" id='new-subject-ids' placeholder="Copy and paste in a list of subject IDs here (separated by spaces, commas, semicolons, or new lines)"></textarea>
-            <p> IDs should not include any identifiable information. For the same reason they are enforced to be numeric </p>
-          </div>
-        </div>
-        
-        <hr />
-        <div class="row form-group">
-            <div class="col-12">
-              <label for="subject-ids-csv" class=" control-label" style="text-weight:bold; font-size:larger">Upload a CSV of  IDs:</label>
-            
-              <input type="file" name = 'subject-ids-csv' class="form-control" id ='subject-ids-csv'><br>
-              <input type="checkbox" name = 'csv-header' id ='csv-header'><label for='ignore-csv-header'>&nbsp; This file has a header row</label><br>
-              <div id = "subj_col_div" class = "collapse">
-                <input type="text" name = "subject-ids-column" id = "subject-ids-column" class="form-control" placeholder="Name of Subject ID Column (ex. subject_id)">
-              </div>
-            </div>
-        </div>
-        <hr />
-        <div class="row form-group">
-            <div class="col-12">
-              <label for="autogenerate-count" class=" control-label" style="text-weight:bold; font-size:larger">Autogenerate Web-CDI ID(s):</label>
-              <p>Use this option to create many links at the same time using Web-CDI IDs.</p>
-              <input type="number" max_value="100" name='autogenerate_count' class="form-control" id ='autogenerate-count' placeholder="Autogenerate XX subject IDs">
-            </div>
-        </div>
-        <script type="text/javascript">
-          $(':file').on('change', function() {
-              var file = this.files[0];
-              if (file.size > 1024) {
-                  alert('max upload size is 1k')
-              }
 
-          });
-
-          $('#csv-header').on('change', function() {
-              if ($('#csv-header').prop('checked')) {
-                  $('#subj_col_div').collapse('show');
-              } else {
-                  $('#subj_col_div').collapse('hide');
-              }
-          });
-
-
-        </script>
-
-        {% if not object.no_demographic_boolean %}
-
-        <hr />
-        <div class="row form-group">  
-          {% if object.single_reusable_link_active %}
-            <div class="col-9" id="reusable_link_div" style = "overflow: hidden; text-overflow: ellipsis;">
-              <label for="add_new_parent" class="control-label" style="text-weight:bold; font-size:larger">Single Reusable Link:</label>
-              <p>
-                <a href="{% url 'researcher_ui:administer_new_parent' username study_name %}" id="reusable_link">Click here</a><br>
-                For mass emails or adding to a website. Does not track IP addresses or use cookies. Every link click creates a new administration.
-              </p>
-              
-              {% if study_group %}
-
-              {% endif %}
-
-              <script type="text/javascript">
-                $('#reusable_link').html($('#reusable_link')[0].href).css;
-                $('#reusable_link').on('click', function() {
-                  $('#reusable_link').hide();
-                })
-
-                //var study_group = "{{ study_group }}";
-                //if (study_group != "") {
-                //  $('#study_group_link').html($('#study_group_link')[0].href);
-                //}
-              </script>
-            </div>
+        <div class="wcdi-muted" style="font-size:13px; margin-bottom:6px;">How do you want to add them?</div>
+        <ul class="nav nav-pills wcdi-method-pills" role="tablist" id="add-method-tabs">
+          <li class="nav-item"><a class="nav-link active" data-toggle="pill" href="#tab-ids" role="tab" data-submit-label="Create links">Enter participant IDs</a></li>
+          <li class="nav-item"><a class="nav-link" data-toggle="pill" href="#tab-generate" role="tab" data-submit-label="Generate links">Generate IDs for me</a></li>
+          <li class="nav-item"><a class="nav-link" data-toggle="pill" href="#tab-csv" role="tab" data-submit-label="Upload and create links">Upload a CSV of IDs</a></li>
+          {% if object.single_reusable_link_active and not object.no_demographic_boolean %}
+          <li class="nav-item"><a class="nav-link" data-toggle="pill" href="#tab-reusable" role="tab" data-submit-label="">Reusable link</a></li>
           {% endif %}
-        </div>
-        {% endif %}
+          {% if object.participant_source_boolean > 0 %}
+          <li class="nav-item"><a class="nav-link" data-toggle="pill" href="#tab-external" role="tab" data-submit-label="">External source</a></li>
+          {% endif %}
+          <li class="nav-item wcdi-method-pill-sep"><a class="nav-link" data-toggle="pill" href="#tab-import" role="tab" data-submit-label="Open the importer" data-submit-action="import">Import completed responses</a></li>
+        </ul>
 
-        {% if object.participant_source_boolean > 0 %}
-        <hr />
-        <div class="row form-group">
-          <div class="col-12" id="prolific_link_div" style = "overflow: hidden; text-overflow: ellipsis;">
-            <label for="add_new_parent" class="control-label" style="text-weight:bold; font-size:larger">External Source Link:</label>
-          
-            <p>
-              <a href="">{{ request.scheme }}://{{ request.META.HTTP_HOST }}{% url 'researcher_ui:administer_new_parent' username study_name %}?source_id={% verbatim %}{{%source_id%}}{% endverbatim %}&event_id={% verbatim %}{{%event_id%}}{% endverbatim %}{% if object.no_demographic_boolean %}&age={% verbatim %}{{%age%}}{% endverbatim %}&sex={% verbatim %}{{%sex%}}{% endverbatim %}&offset={% verbatim %}{{%offset%}}{% endverbatim %}{% endif %}</a><br>
-            (This link will not open a new administration.  It is to be copied into External Source and will enable opening on a new child capturing the External Source Id from there. 
-            Event_id is optional.  If event_id is specified it will create a new administration (if different to previous event_id).
-            {% if not object.no_demographic_boolean %}If you want a link with a blank source Id, use the Single Reusable Link.{% endif %})
-            </p>
+        <div class="tab-content wcdi-method-panels">
+
+          <div class="tab-pane fade show active" id="tab-ids" role="tabpanel">
+            <p class="wcdi-method-help">One link per ID. Enter the same ID again later to add a second administration for that child.
+              IDs must be numeric and must not identify anyone.</p>
+            <label for="new-subject-ids" class="sr-only">Participant IDs</label>
+            <textarea name="new_subject_ids" class="form-control" rows="4" id="new-subject-ids"
+                      placeholder="1101, 1102, 1103 &mdash; separated by spaces, commas, or new lines"></textarea>
           </div>
-        </div>
-        {% endif %}
 
+          <div class="tab-pane fade" id="tab-generate" role="tabpanel">
+            <p class="wcdi-method-help">Web-CDI assigns the IDs. Useful for running many children at a site on the same day
+              (e.g. a children's museum).</p>
+            <label for="autogenerate-count" class="wcdi-method-label">How many?</label>
+            <input type="number" min="1" max="100" name="autogenerate_count" class="form-control" id="autogenerate-count"
+                   placeholder="e.g. 20" style="max-width:160px;">
+          </div>
+
+          <div class="tab-pane fade" id="tab-csv" role="tabpanel">
+            <p class="wcdi-method-help">One ID per row. If the file has a header row, tick the box and tell us which column holds the IDs.</p>
+            <label for="subject-ids-csv" class="wcdi-method-label">CSV file</label>
+            <input type="file" name="subject-ids-csv" class="form-control-file" id="subject-ids-csv" accept=".csv,text/csv">
+            <div class="form-check" style="margin-top:10px;">
+              <input type="checkbox" class="form-check-input" name="csv-header" id="csv-header">
+              <label class="form-check-label" for="csv-header">This file has a header row</label>
+            </div>
+            <div id="subj_col_div" class="collapse" style="margin-top:8px;">
+              <input type="text" name="subject-ids-column" id="subject-ids-column" class="form-control"
+                     placeholder="Name of the ID column (e.g. subject_id)" style="max-width:320px;">
+            </div>
+          </div>
+
+          {% if object.single_reusable_link_active and not object.no_demographic_boolean %}
+          <div class="tab-pane fade" id="tab-reusable" role="tabpanel">
+            <p class="wcdi-method-help">For mass emails, websites, or anonymous recruitment (e.g. Facebook, Prolific).
+              Every click on this link creates a new administration with a Web-CDI ID. No IP addresses or cookies are used.</p>
+            <div class="wcdi-link-row">
+              <input type="text" readonly class="form-control" id="reusable_link_input"
+                     value="{{ request.scheme }}://{{ request.META.HTTP_HOST }}{% url 'researcher_ui:administer_new_parent' username study_name %}">
+              <button type="button" class="btn btn-secondary" data-copy="#reusable_link_input">Copy</button>
+            </div>
+          </div>
+          {% endif %}
+
+          {% if object.participant_source_boolean > 0 %}
+          <div class="tab-pane fade" id="tab-external" role="tabpanel">
+            <p class="wcdi-method-help">Paste this into your external platform (e.g. Prolific). It does not open an administration
+              itself; it lets the platform create one per child and records the platform's participant ID as
+              <code>source_id</code>. <code>event_id</code> is optional &mdash; a different event_id creates a new administration.
+              {% if not object.no_demographic_boolean %}For a link with no source ID, use the reusable link.{% endif %}</p>
+            <div class="wcdi-link-row">
+              <input type="text" readonly class="form-control" id="external_link_input"
+                     value="{{ request.scheme }}://{{ request.META.HTTP_HOST }}{% url 'researcher_ui:administer_new_parent' username study_name %}?source_id={% verbatim %}{{%source_id%}}{% endverbatim %}&event_id={% verbatim %}{{%event_id%}}{% endverbatim %}{% if object.no_demographic_boolean %}&age={% verbatim %}{{%age%}}{% endverbatim %}&sex={% verbatim %}{{%sex%}}{% endverbatim %}&offset={% verbatim %}{{%offset%}}{% endverbatim %}{% endif %}">
+              <button type="button" class="btn btn-secondary" data-copy="#external_link_input">Copy</button>
+            </div>
+          </div>
+          {% endif %}
+
+          <div class="tab-pane fade" id="tab-import" role="tabpanel">
+            <p class="wcdi-method-help">Already have completed forms? Web-CDI can import the CSV that the English MB-CDI fillable
+              PDFs export (Words &amp; Gestures and Words &amp; Sentences), creating a <em>completed</em> administration per row.
+              The importer has templates to download and notes on the required columns.</p>
+          </div>
+
+        </div>
+
+        <div class="wcdi-muted" style="font-size:12.5px; margin-top:12px;">
+          Links expire {{ object.test_period }} day{{ object.test_period|pluralize }} after they are created (change this in the group settings).
+          See the <a href="{% url 'documentation' %}#participants" target="_blank">documentation</a> for more on each method.
+        </div>
       </form>
-      <div class="alert alert-danger error-message" role="alert" style="display:none">
-            <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-              <span class="sr-only">Error:</span>
-              <div style='display:inline' id='error-message-text'></div>
+
+      <div class="alert alert-danger error-message" role="alert" style="display:none; margin-top:12px;">
+            <span class="sr-only">Error:</span>
+            <div style='display:inline' id='error-message-text'></div>
+      </div>
       </div>
 
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-        <input id="id_modal_submit_btn" name="submit" value="Submit" class="btn btn-primary" type="button">
+        <button type="button" class="btn btn-link wcdi-nav-link" data-dismiss="modal">Cancel</button>
+        <input id="id_modal_submit_btn" name="submit" value="Create links" class="btn btn-primary" type="button">
+        <button id="id_modal_import_btn" type="button" class="btn btn-primary" style="display:none;"
+                onclick="modal_form('{% url 'researcher_ui:import_data' object.pk %}')">Open the importer</button>
       </div>
     </div>
   </div>
+
+  <script type="text/javascript">
+    (function () {
+      // Footer button follows the active tab: label, or hidden for link-only tabs,
+      // or hands off to the importer dialog.
+      var submitBtn = $('#id_modal_submit_btn'), importBtn = $('#id_modal_import_btn');
+      function syncFooter(link) {
+        var label = $(link).data('submit-label');
+        var action = $(link).data('submit-action');
+        importBtn.toggle(action === 'import');
+        submitBtn.toggle(action !== 'import' && !!label);
+        if (label && action !== 'import') submitBtn.val(label);
+      }
+      $('#add-method-tabs a[data-toggle="pill"]').on('shown.bs.tab', function (e) { syncFooter(e.target); });
+      syncFooter($('#add-method-tabs a.active')[0]);
+
+      $('#csv-header').on('change', function () {
+        $('#subj_col_div').collapse($(this).prop('checked') ? 'show' : 'hide');
+      });
+      $('#subject-ids-csv').on('change', function () {
+        var file = this.files[0];
+        if (file && file.size > 1024 * 1024) { alert('Please keep the CSV under 1 MB.'); this.value = ''; }
+      });
+
+      // Copy buttons for the link tabs
+      $('#modal-form [data-copy]').on('click', function () {
+        var input = document.querySelector($(this).data('copy')), btn = $(this);
+        input.select();
+        var done = function () { btn.text('Copied'); setTimeout(function () { btn.text('Copy'); }, 1400); };
+        if (navigator.clipboard) { navigator.clipboard.writeText(input.value).then(done); }
+        else { document.execCommand('copy'); done(); }
+      });
+    })();
+  </script>

--- a/webcdi/researcher_UI/templates/researcher_UI/import_data.html
+++ b/webcdi/researcher_UI/templates/researcher_UI/import_data.html
@@ -1,61 +1,51 @@
 {% load static %}
-<!-- Modal window for grouping studies together -->
+<!-- Import completed responses from a CSV (reached from the last tab of the add-administrations dialog) -->
 
   <div class="modal-dialog modal-lg" role="document">
     <div class="modal-content">
       <div class="modal-header">
+        <h4 class="modal-title">Import completed responses</h4>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" >Import spreadsheet</h4>
       </div>
       <div class="modal-body">
-        <div>
-          Web-CDI can now import CSV files created by English-language MB-CDI fillable PDFs! Spreadsheets which follow the exact formats below (column names must be exact) can be added into Web-CDI with no issues:
-          <br>
-
-          <ul>
-            <li><a href="{% static 'data_csv/CDI_Words_and_Gestures_responses.csv' %}" download> For English Words &amp; Gestures</a></li>
-            <li><a href="{% static 'data_csv/CDI_Words_and_Sentences_responses.csv' %}" download> For English Words &amp; Sentences</a></li>
-          </ul>
-
-          You can also add demographic data to your spreadsheet! You can edit your original spreadsheet and add columns and data entries that match up with Web-CDI's own system. You can check out <a href="{% static 'data_csv/CDI_demo_mappings.csv' %}" download> this CSV </a> of available demographic fields, raw values, and their meanings to create sheets that look more like the ones below.
-
-          <ul>
-            <li><a href="{% static 'data_csv/CDI_Words_and_Gestures_responses_withdemos.csv' %}" download> For English Words &amp; Gestures (with demographic data)</a></li>
-            <li><a href="{% static 'data_csv/CDI_Words_and_Sentences_responses_withdemos.csv' %}" download> For English Words &amp; Sentences (with demographic data)</a></li>
-          </ul>
-
-          Notes: 
-          <ul>
-            <li>The column 'name_of_child' is converted into a Subject ID column which means it must be numeric. If anybody in your study already has a Subject ID found in this column, Web-CDI will assume this is a longitudinal subject and will assign the same Subject ID with a higher administration #.</li>
-            <li>The 'Expiration Date' and 'Last Modified' fields will refer to the date found in the 'date_today' column. However the 'Creation Date' field will refer to when this data was imported into Web-CDI. This creates a row where the 'Creation Date' field will likely occur after the 'Expiration Date'.</li>
-          </ul>
-
-        </div>
+        <p>Web-CDI can import CSV files created by the English-language MB-CDI fillable PDFs. Each row becomes a
+          <strong>completed</strong> administration in this group. Column names must match these templates exactly:</p>
+        <ul>
+          <li><a href="{% static 'data_csv/CDI_Words_and_Gestures_responses.csv' %}" download>English Words &amp; Gestures</a></li>
+          <li><a href="{% static 'data_csv/CDI_Words_and_Sentences_responses.csv' %}" download>English Words &amp; Sentences</a></li>
+        </ul>
+        <p>You can also include demographic data by adding columns that match Web-CDI's fields &mdash; see
+          <a href="{% static 'data_csv/CDI_demo_mappings.csv' %}" download>this CSV</a> of available fields, raw values,
+          and their meanings, and these templates:</p>
+        <ul>
+          <li><a href="{% static 'data_csv/CDI_Words_and_Gestures_responses_withdemos.csv' %}" download>English Words &amp; Gestures with demographics</a></li>
+          <li><a href="{% static 'data_csv/CDI_Words_and_Sentences_responses_withdemos.csv' %}" download>English Words &amp; Sentences with demographics</a></li>
+        </ul>
+        <p class="wcdi-muted" style="font-size:13px;">Notes: the <code>name_of_child</code> column becomes the Subject ID, so it must be numeric; a value that
+          already exists in this group is treated as the same child and gets the next administration number.
+          Expiration and last-modified dates come from <code>date_today</code>; the creation date is the import date,
+          so creation can appear after expiration.</p>
         <hr>
         {% load crispy_forms_tags %}
         {% crispy form %}
-    </div>
-    {% if form.errors %}
+      </div>
+      {% if form.errors %}
         {% for field in form %}
             {% for error in field.errors %}
-                <div class="alert alert-error">
-                    <strong>{{ error|escape }}</strong>
-                </div>
+                <div class="alert alert-danger"><strong>{{ error|escape }}</strong></div>
             {% endfor %}
         {% endfor %}
         {% for error in form.non_field_errors %}
-            <div class="alert alert-error">
-                <strong>{{ error|escape }}</strong>
-            </div>
+            <div class="alert alert-danger"><strong>{{ error|escape }}</strong></div>
         {% endfor %}
-    {% endif %}
+      {% endif %}
       <div class="alert alert-danger error-message" role="alert" style="display:none">
-            <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-              <span class="sr-only">Error:</span>
-              <div style='display:inline' id='error-message-text'></div>
+            <span class="sr-only">Error:</span>
+            <div style='display:inline' id='error-message-text'></div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-        <input name="submit" value="Submit" class="btn btn-primary" type="button">
+        <button type="button" class="btn btn-link wcdi-nav-link" data-dismiss="modal">Cancel</button>
+        <input name="submit" value="Import responses" class="btn btn-primary" type="button">
       </div>
+    </div>
   </div>

--- a/webcdi/researcher_UI/templates/researcher_UI/interface.html
+++ b/webcdi/researcher_UI/templates/researcher_UI/interface.html
@@ -10,7 +10,7 @@
                     <div class="wcdi-muted">Each group administers one CDI form to a set of participants.</div>
                 </div>
                 <div style="margin-left:auto;">
-                    <a id="id_new_study" href="{% url 'researcher_ui:add_study' %}" class="btn btn-primary">+ New administration group</a>
+                    <a id="id_new_study" href="{% url 'researcher_ui:add_study' %}" class="btn btn-primary">New administration group</a>
                 </div>
             </div>
 
@@ -40,7 +40,7 @@
                     <ol style="padding-left:20px;">
                         <li style="margin-bottom:6px;"><a href="{% url 'researcher_ui:researcher_add_instruments' pk=request.user.researcher.pk %}">Select the CDI instruments</a> you plan to use (some require a Brookes Publishing access code).</li>
                         <li style="margin-bottom:6px;"><a href="{% url 'researcher_ui:add_study' %}">Create an administration group</a> — one per form, e.g. one group for Words &amp; Gestures and one for Words &amp; Sentences.</li>
-                        <li>Add participants to the group and send them their links.</li>
+                        <li>Add administrations to the group and send participants their links.</li>
                     </ol>
                     <p style="margin-bottom:0;">The <a href="{% url 'documentation' %}">documentation</a> walks through the whole workflow.</p>
                 </div>
@@ -60,6 +60,7 @@
                     </div>
                 </div>
                 <div style="margin-left:auto; min-width:230px;">
+                    <label for="study-selector" class="sr-only">Switch group</label>
                     <select id="study-selector" class="form-control" onchange="location = encodeURI(this.options[this.selectedIndex].value);">
                         {% for study in studies %}
                             <option value="{% url 'researcher_ui:console_study' pk=study.pk %}"{% if study.pk == current_study.pk %} selected="" {% endif %}>{{ study }}</option>
@@ -68,83 +69,83 @@
                 </div>
             </div>
 
-            <form method='post'  action='{% url "researcher_ui:console_study" pk=current_study.pk %}' id='study-form'>
-        {% if current_study %}
-            <div class="wcdi-toolbar" style="margin-top:14px;">
-                <div class="btn-group">
-                    <button id="id_add_participants" type="button" class="btn btn-primary" title="Enter your own ID for a single child or tell Web-CDI to generate IDs for you." onclick = "modal_form('/interface/study/{{ current_study.pk|urlencode }}/administer_new/')">Add Administrations</button>
-                    <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <span class="sr-only">Toggle Dropdown</span>
-                    </button>
-                    <div class="dropdown-menu">
-                        <button type="button" class="dropdown-item"   onclick = "modal_form('/interface/study/{{ current_study.pk|urlencode }}/import_data/')" >Import Spreadsheet Data</button>
-                    </div>
-                </div>
-                <div class="dropdown">
-                    <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Download All</button>
-                    <div class="dropdown-menu" aria-labelledby="dropdownMenu2">
-                        <button class="dropdown-item" type="submit" name='download-summary-csv' id='download-summary-csv'>Summary Scores/Percentiles (csv)</button>
-                        <button class="dropdown-item" type="submit" name='download-study-csv' id='download-study-csv'>Items and Summary Scores/Percentiles (csv)</button>
-                        <button class="dropdown-item" type="submit" name='download-study-csv-adjusted' id='download-study-csv-adjusted'>Items and Summary Scores/Percentiles with Adjusted Ages (csv)</button>
-                    </div>
-                </div>
-                <a id="id_update_study" class="btn btn-secondary" href="{% url 'researcher_ui:rename_study' pk=current_study.pk %}" >Update Group</a>
-                <button type="submit" class="btn btn-secondary wcdi-btn-danger" style="margin-left:auto;" name='delete-study' id='delete-study' onclick='return confirm("Are you sure you want to delete the entire study and all the data associated with it?");' >Delete Group</button>
-            </div>
-        {% endif %}
+            <form method='post' action='{% url "researcher_ui:console_study" pk=current_study.pk %}' id='study-form'>
+            {% csrf_token %}
 
-        {% if current_study %}
+            {# ---- primary toolbar: one verb each ---- #}
+            <div class="wcdi-toolbar" style="margin-top:14px;">
+                <button id="id_add_participants" type="button" class="btn btn-primary"
+                        onclick="modal_form('{% url 'researcher_ui:administer_new' current_study.pk %}')">Add administrations</button>
+
+                <div class="dropdown">
+                    <button class="btn btn-secondary dropdown-toggle" type="button" id="download-menu-btn" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Download</button>
+                    <div class="dropdown-menu wcdi-download-menu" aria-labelledby="download-menu-btn">
+                        <div class="dropdown-header wcdi-scope-all">All administrations</div>
+                        <div class="dropdown-header wcdi-scope-selected" style="display:none;"><span class="wcdi-sel-count">0</span> selected administrations</div>
+                        <button class="dropdown-item" type="submit" name="download-summary-csv" data-all="download-summary-csv" data-selected="download-selected-summary">Summary scores &amp; percentiles (csv)</button>
+                        <button class="dropdown-item" type="submit" name="download-study-csv" data-all="download-study-csv" data-selected="download-selected">Items + summary scores (csv)</button>
+                        <button class="dropdown-item" type="submit" name="download-study-csv-adjusted" data-all="download-study-csv-adjusted" data-selected="download-selected-adjusted">Items + summary scores, adjusted ages (csv)</button>
+                        <div class="dropdown-divider"></div>
+                        {# These need a selection: the PDF report is per row and the links export has no whole-group variant #}
+                        <a id="id_select_clinical" class="dropdown-item wcdi-needs-selection" href="#" onclick="return open_clinical_report(this, '{% url 'researcher_ui:pdf_summary' current_study.pk %}');">Clinical report (pdf) <span class="wcdi-needs-hint">— select rows first</span></a>
+                        <a id="id_select_clinical_adjusted" class="dropdown-item wcdi-needs-selection" href="#" onclick="return open_clinical_report(this, '{% url 'researcher_ui:pdf_summary_adjusted' current_study.pk 'adjusted' %}');">Clinical report, adjusted ages (pdf) <span class="wcdi-needs-hint">— select rows first</span></a>
+                        {% if not study.instrument.form == 'CAT' %}
+                        <button class="dropdown-item wcdi-needs-selection" type="submit" name="download-links" disabled>Participant links (csv) <span class="wcdi-needs-hint">— select rows first</span></button>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <a id="id_update_study" class="btn btn-secondary" href="{% url 'researcher_ui:rename_study' pk=current_study.pk %}">Group settings</a>
+            </div>
+
+            {# ---- selection toolbar ---- #}
             <div id='administration-form'>
                 <div class="wcdi-toolbar" style="margin-top:10px;">
-                    <div style="flex:1; min-width:220px; max-width:320px;">
-                        <input id='id_search' type="text" placeholder="Search by Participant ID...." name="search">
-                        <button id='search_button' type="submit"><i class="fa fa-search"></i></button>
+                    <div style="flex:1; min-width:220px; max-width:340px;">
+                        <label for="id_search" class="sr-only">Search by participant ID</label>
+                        <input id='id_search' type="text" placeholder="Search by participant ID…" name="search">
+                        <button id='search_button' type="submit" aria-label="Search"><i class="fa fa-search"></i></button>
                     </div>
-                    <span class="wcdi-muted" style="font-size:13px;">With selected:</span>
-                    <button class="btn btn-secondary selected-btn" id='add-selected' type='submit' name='administer-selected' value='administer-selected' disabled  >Re-administer</button>
-                    <div class="dropdown selected-btn" >
-                        <button class="btn btn-secondary selected-btn dropdown-toggle" type="button" id="dropdownMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" disabled>Download</button>
-                        <div class="dropdown-menu" aria-labelledby="dropdownMenu">
-                            <a id="id_select_clinical" class="dropdown-item selected-btn" onclick="javascript:append_url_checkboxes()">Clinical Report (pdf)</a>
-                            <a id="id_select_clinical_adjusted" class="dropdown-item selected-btn" onclick="javascript:append_url_checkboxes_adjusted()">Clinical Report with Adjusted Ages (pdf)</a>
-                            <button class="dropdown-item selected-btn" id='download-selected-summary' type="submit" name='download-selected-summary' value='download-selected-summary' disabled>Summary Scores/Percentiles Only (csv)</button>
-                            <button class="dropdown-item selected-btn" id='download-selected' type='submit' name='download-selected' value='download-selected'  disabled >Items and Summary Scores/Percentiles (csv)</button>
-                            <button class="dropdown-item selected-btn" id='download-selected-adjusted' type='submit' name='download-selected-adjusted' value='download-selected-adjusted'  disabled >Items and Summary Scores/Percentiles with Adjusted Ages (csv)</button>
-                            {% if not study.instrument.form == 'CAT' %}
-                            <button class="dropdown-item selected-btn" id='download-links' type='submit' name='download-links' value='download-links'  disabled >Links only (csv)</button>
-                            {% endif %}
-
-                        </div>
-                    </div>
-                    <button class="btn btn-secondary selected-btn wcdi-btn-danger" id='delete-selected' type='submit' name='delete-selected' value='administer-selected' disabled onclick='return confirm("Are you sure you want to delete the selected administration record and all the data associated with it?");' >Delete</button>
+                    <span class="wcdi-muted wcdi-selection-label" style="font-size:13px; margin-left:auto;"><span class="wcdi-sel-count">0</span> selected</span>
+                    <button class="btn btn-secondary selected-btn" id='add-selected' type='submit' name='administer-selected' value='administer-selected' disabled
+                            title="Create a new administration for each selected participant">Re-administer</button>
+                    <button class="btn btn-secondary selected-btn wcdi-btn-danger" id='delete-selected-open' type='button' disabled
+                            data-toggle="modal" data-target="#delete-selected-modal">Delete</button>
                 </div>
 
                 <div>
-                        {% include "researcher_UI/table.html" with table=study_administrations %}
-                        <script type="text/javascript">
-                            var utc_time;
-                            var local_time;
-                            $('.due_date, .last_modified, .created_date').not('.orderable, .sortable').each( function () {
-                                utc_time = moment.utc($(this).html(), "MM/DD/YYYY hh:mm a");
-                                local_time = moment(utc_time).local().format("MM/DD/YYYY hh:mm a");
-                                $(this).html(local_time);
-                            });
-                        </script>
+                    {% include "researcher_UI/table.html" with table=study_administrations %}
                 </div>
             </div>
 
-        {% endif %}
+            {# ---- delete selected: proper confirm, posts the existing delete-selected ---- #}
+            <div class="modal" id="delete-selected-modal" tabindex="-1" role="dialog" aria-labelledby="delete-selected-title">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title wcdi-danger-text" id="delete-selected-title">Delete <span class="wcdi-sel-count">0</span> administration<span class="wcdi-sel-plural">s</span>?</h5>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                        </div>
+                        <div class="modal-body">
+                            <p style="margin:0;">Their responses and scores are removed from this group. <strong>This cannot be undone from your account.</strong>
+                               If there is any chance you will want these data, download them first.</p>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-link wcdi-nav-link" data-dismiss="modal">Cancel</button>
+                            <button type="submit" class="btn wcdi-btn-danger-solid" id="delete-selected" name="delete-selected" value="delete-selected">Delete</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
             </form>
         {% endif %}
     </div>
-    <!-- New Study Modal -->
-    <div class="modal" id="modal-form" tabindex="" role="dialog" aria-labelledby="new study"></div>
+    <!-- Shared modal container for the add-administrations / import dialogs -->
+    <div class="modal" id="modal-form" tabindex="" role="dialog" aria-labelledby="modal-title"></div>
 {% endblock %}
 
 {% block scripts %}
 <script>
-    // Function from static/researcher_UI.js. Disables the 'selected' buttons unless at least one of the checkboxes in select_col is selected.
-    checked_only()
     $('form').each(function(){this.onkeypress = checkEnter;});
 
     // Tracks the number of administrations to be displayed per page.
@@ -175,68 +176,56 @@
             }
         }
     });
-    var shifted = false;
 
     // Checkboxes selected while Shift button is held down select all checkboxes in between as well
     var lastChecked = null;
     var handleChecked = function(e) {
-        shifted = e.shiftKey;
-        if(lastChecked && shifted) {
-            var i = $('input[type="checkbox"]').index(lastChecked);
-            var j = $('input[type="checkbox"]').index(e.target);
-            var checkboxes = [];
-            if (j > i) {
-                checkboxes = $('input[type="checkbox"]:gt('+ (i-1) +'):lt('+ (j-i) +')');
-            } else {
-                checkboxes = $('input[type="checkbox"]:gt('+ j +'):lt('+ (i-j) +')');
-            }
-            if (!$(e.target).is(':checked')) {
-                $(checkboxes).prop('checked', false);
-            } else {
-                $(checkboxes).prop('checked', true);
-            }
+        if (lastChecked && e.shiftKey) {
+            var boxes = $('input[name="select_col"]');
+            var i = boxes.index(lastChecked);
+            var j = boxes.index(e.target);
+            var lo = Math.min(i, j), hi = Math.max(i, j);
+            boxes.slice(lo, hi + 1).prop('checked', $(e.target).is(':checked'));
         }
         lastChecked = e.target;
     }
+    $('input[name="select_col"]').click(function(e) { handleChecked(e); });
 
-    $('input[name="select_col"').click( function() {
-        handleChecked(event);
-    });
-
-    // Check for the number of completed tests as reported by Django. If none of the tests are completed, disables download_data option.
-    var completed_admins = "{{ completed_admins }}";
-
-    if (parseInt("{{ completed_admins }}")) {
-        $('#download-study').removeClass('disabled');
-    } else
-    {
-        $('#download-study').addClass('disabled');
-    }
-</script>
-
-<script>
-    // This add ticked items to url call for Clinical/PDF downloads
     {% if current_study %}
-    append_url_checkboxes = function (){
-        var url = new URL("{{ request.scheme }}://{{request.get_host }}{% url 'researcher_ui:pdf_summary' current_study.pk %}");
-        var checkedBoxes = document.querySelectorAll('input[name=select_col]:checked');
-        for (let i = 0; i < checkedBoxes.length; i++) {
-            url.searchParams.append('id', checkedBoxes[i].value);
-          }
- 
-        $('#id_select_clinical').attr('href', url)
-        //window.open(url)
-        }
-    append_url_checkboxes_adjusted = function (){
-        var url = new URL("{{ request.scheme }}://{{request.get_host }}{% url 'researcher_ui:pdf_summary_adjusted' current_study.pk 'adjusted' %}");
-        var checkedBoxes = document.querySelectorAll('input[name=select_col]:checked');
-        for (let i = 0; i < checkedBoxes.length; i++) {
-            url.searchParams.append('id', checkedBoxes[i].value);
-            }
-    
-        $('#id_select_clinical_adjusted').attr('href', url)
-        //window.open(url)
-        }
+    // ---- selection-aware toolbar ----
+    // One Download menu: with nothing ticked it posts the whole-group names,
+    // with rows ticked it posts the selected-rows names (same view handlers).
+    function selectedIds() {
+        return $('input[name="select_col"]:checked').map(function () { return this.value; }).get();
+    }
+    function syncSelection() {
+        var n = selectedIds().length;
+        $('.wcdi-sel-count').text(n);
+        $('.wcdi-sel-plural').text(n === 1 ? '' : 's');
+        $('.selected-btn').prop('disabled', n === 0);
+        $('.wcdi-download-menu [data-all]').each(function () {
+            $(this).attr('name', n > 0 ? $(this).data('selected') : $(this).data('all'));
+        });
+        $('.wcdi-download-menu .wcdi-needs-selection').toggleClass('disabled', n === 0)
+            .filter('button').prop('disabled', n === 0);
+        $('.wcdi-needs-hint').toggle(n === 0);
+        $('.wcdi-scope-all').toggle(n === 0);
+        $('.wcdi-scope-selected').toggle(n > 0);
+    }
+    $(document).on('change', 'input[name="select_col"], thead input[type="checkbox"]', syncSelection);
+    // the header select-all checkbox toggles via toggle(); catch it after it runs
+    $(document).on('click', 'thead input[type="checkbox"]', function () { setTimeout(syncSelection, 0); });
+    syncSelection();
+
+    // Clinical reports are per-row PDFs: build the URL from the ticked rows.
+    function open_clinical_report(el, base) {
+        var ids = selectedIds();
+        if (!ids.length) return false;
+        var url = new URL(base, window.location.origin);
+        ids.forEach(function (id) { url.searchParams.append('id', id); });
+        window.open(url.toString(), '_blank');
+        return false;
+    }
     {% endif %}
 </script>
 {% endblock %}

--- a/webcdi/researcher_UI/templates/researcher_UI/study_form.html
+++ b/webcdi/researcher_UI/templates/researcher_UI/study_form.html
@@ -2,18 +2,19 @@
 {% extends 'researcher_UI/base.html' %}
 {% load i18n static %}
 
-{% block title %}WebCDI Interface: Add Study{% endblock %}
+{% block title %}{% if form_name %}Group settings · {{ study_obj.name }}{% else %}New administration group{% endif %}{% endblock %}
 {% block main %}
 {{ block.super }}
-<div style="margin-top:100px; margin-bottom:10rem;">
+<div style="margin-top:40px; margin-bottom:6rem;">
   <div>
     <div class="container" style="padding-bottom:2rem;">
           <div class="modal-header">
             <h4 id="modal-title" class="modal-title" >
               {% if form_name %}
-                Update Administration Group - {{ study_obj.instrument }}
+                Group settings &middot; {{ study_obj.name }}
+                <div class="wcdi-muted" style="font-size:14px; font-weight:400; margin-top:2px;">{{ study_obj.instrument }} &middot; the instrument cannot be changed after creation</div>
               {% else %}
-                Add new Administration Group
+                New administration group
               {% endif %}
             </h4>
           </div>
@@ -376,6 +377,59 @@
                   <span class="sr-only">Error:</span>
                   <div style='display:inline' id='error-message-text'></div>
           </div>
+
+          {% if form_name %}
+          {# ---- danger zone: deleting the group. Rare, so it lives here rather than on the group page. ---- #}
+          {% with n_admins=study_obj.administration_set.count %}
+          <div class="wcdi-danger-zone" id="danger-zone">
+            <div>
+              <h2>Delete this group</h2>
+              <p>Removes <strong>{{ study_obj.name }}</strong> and all {{ n_admins }} administration{{ n_admins|pluralize }} in it, including every response and score. This cannot be undone from your account.</p>
+            </div>
+            <button type="button" class="btn btn-secondary wcdi-btn-danger" data-toggle="modal" data-target="#delete-group-modal">Delete group&hellip;</button>
+          </div>
+
+          <div class="modal" id="delete-group-modal" tabindex="-1" role="dialog" aria-labelledby="delete-group-title">
+            <div class="modal-dialog" role="document">
+              {# posts the existing delete-study action to the group page's handler #}
+              <form method="post" action="{% url 'researcher_ui:console_study' pk=study_obj.pk %}" id="delete-group-form">
+                {% csrf_token %}
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h5 class="modal-title wcdi-danger-text" id="delete-group-title">Delete &ldquo;{{ study_obj.name }}&rdquo;?</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                  </div>
+                  <div class="modal-body">
+                    <p>This permanently removes the group <strong>{{ study_obj.name }}</strong> and all
+                      <strong>{{ n_admins }} administration{{ n_admins|pluralize }}</strong> in it, including every response and score.
+                      <strong>This cannot be undone from your account.</strong> Be sure you will never want these data again
+                      &mdash; download them first if there is any doubt.</p>
+                    <label for="delete-group-confirm" style="font-size:13.5px; font-weight:600;">Type <code>{{ study_obj.name }}</code> to confirm</label>
+                    <input type="text" class="form-control" id="delete-group-confirm" autocomplete="off" spellcheck="false" data-expected="{{ study_obj.name }}">
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-link wcdi-nav-link" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn wcdi-btn-danger-solid" id="delete-group-submit" name="delete-study" value="delete-study" disabled>Delete this group</button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+          <script>
+            // The red button only arms when the typed name matches exactly.
+            (function () {
+              var input = document.getElementById('delete-group-confirm');
+              var submit = document.getElementById('delete-group-submit');
+              var expected = input.getAttribute('data-expected');
+              input.addEventListener('input', function () { submit.disabled = (input.value !== expected); });
+              $('#delete-group-modal').on('shown.bs.modal', function () { input.value = ''; submit.disabled = true; input.focus(); });
+              document.getElementById('delete-group-form').addEventListener('submit', function (e) {
+                if (input.value !== expected) e.preventDefault();
+              });
+            })();
+          </script>
+          {% endwith %}
+          {% endif %}
     </div>
   </div>
 </div>

--- a/webcdi/researcher_UI/templates/researcher_UI/table.html
+++ b/webcdi/researcher_UI/templates/researcher_UI/table.html
@@ -5,25 +5,17 @@
 {% if table.page %}
     <div class="table-container">
 {% endif %}
- 
+
 {% block table %}
 <script>
     function edit_function(id){
         $('#'+id).modal()
     }
-    function Convert_to_localtime(utcDate){
-        let newStr = utcDate.replace('p.m.','PM');
-        newStr = newStr.replace('a.m.','AM');
-        const date = new Date(newStr); 
-        var local_date = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(),  date.getHours(), date.getMinutes(), date.getSeconds()));
-        var local_date_formatted= local_date.toLocaleString([], { hour12: true});
-        return local_date_formatted
-    }
     const edit_study_new = (id) =>{
        $(".overlay").fadeIn(300);
 
        const csrf_token = document.getElementsByName("csrfmiddlewaretoken")[0].value;
-       const url =  $('#form_modal_hidden_id'+id).val();   
+       const url =  $('#form_modal_hidden_id'+id).val();
         $.ajax({
         type: "POST",
         url: url,
@@ -48,99 +40,9 @@
         }
         });
     }
-    
 </script>
 <style>
-    .login-card {
-        padding: 40px;
-        margin: 0 auto 10px;
-        border-radius: 10px;
-        overflow: scroll;
-      
-      }
-      .login-card h1{
-        color: white;
-      }
-      .input-row{
-        margin-top: 15px;
-      }
-      
-      .login-card input[type=submit] {
-        width: 100%;
-        display: block;
-        margin-bottom: 10px;
-        position: relative;
-        border-radius: 10px;
-      
-      }
-      .login-card input[type=button] {
-        width: 100%;
-        display: block;
-        margin-bottom: 10px;
-        position: relative;
-        border-radius: 10px;
-        background: red;
-      
-      }
-      
-      .login-card input[type=text], input[type=password] {
-        height: 44px;
-        font-size: 12px;
-        width: 100%;
-        margin-bottom: 10px;
-        -webkit-appearance: none;
-        background: #fff;
-        border: 1px solid #d9d9d9;
-        border-top: 1px solid #c0c0c0;
-        /* border-radius: 2px; */
-        padding: 0 8px;
-        box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        border-radius: 10px;
-      
-      }
-      .login-card input[type=text], input[type=email] {
-        height: 44px;
-        font-size: 12px;
-        width: 100%;
-        margin-bottom: 10px;
-        -webkit-appearance: none;
-        background: #fff;
-        border: 1px solid #d9d9d9;
-        border-top: 1px solid #c0c0c0;
-        /* border-radius: 2px; */
-        padding: 0 8px;
-        box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        border-radius: 10px;
-      
-      }
-      .login-card select {
-        height: 44px;
-        font-size: 12px;
-        width: 100%;
-        margin-bottom: 10px;
-        -webkit-appearance: none;
-        background: #fff;
-        border: 1px solid #d9d9d9;
-        border-top: 1px solid #c0c0c0;
-        /* border-radius: 2px; */
-        padding: 0 8px;
-        box-sizing: border-box;
-        -moz-box-sizing: border-box;
-        border-radius: 10px;
-      
-      }
-      .login-card input[type=text]:hover, input[type=password]:hover {
-        border: 1px solid #b9b9b9;
-        border-top: 1px solid #a0a0a0;
-        -moz-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
-        -webkit-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
-        box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
-        border-radius: 10px;
-      
-      }
-    .overlay{	
+    .overlay{
     position: fixed;
     top: 0;
     z-index: 100;
@@ -153,7 +55,7 @@
     height: 100%;
     display: flex;
     justify-content: center;
-    align-items: center;  
+    align-items: center;
     }
     .spinner {
     width: 40px;
@@ -164,123 +66,138 @@
     animation: sp-anime 0.8s infinite linear;
     }
     @keyframes sp-anime {
-    100% { 
-        transform: rotate(360deg); 
+    100% {
+        transform: rotate(360deg);
     }
     }
-    .is-hide{
-    display:none;
-    }
-
 </style>
 
-<table class="table">
+<div class="wcdi-table-scroll">
+<table class="table wcdi-admin-table">
     {% block table.thead %}
         {% if table.show_header %}
             <thead {{ table.attrs.thead.as_html }}>
                 <tr>
                 {% for column in table.columns %}
-                    <th {{ column.attrs.th.as_html }} style="text-align:center;">
+                    <th {{ column.attrs.th.as_html }} class="wcdi-col-{{ column.name }}">
                         {% if column.orderable %}
-                            <a href="{% querystring sort=column.order_by_alias.next %}">{{ column.header }}</a>
+                            <a class="column_sort_links" href="{% querystring sort=column.order_by_alias.next %}">{{ column.header }}</a>
                         {% else %}
                             {{ column.header }}
                         {% endif %}
                     </th>
                 {% endfor %}
-                <th> Action </th>
                 </tr>
             </thead>
         {% endif %}
     {% endblock table.thead %}
-    
+
     <tbody>
-    {% for row in table.paginated_rows %}      
+    {% for row in table.paginated_rows %}
         <tr>
-            <!--Modal-->
-            <div class="modal" id="{{row.record.pk}}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
-                <form class="login-card"  action="{% url 'researcher_ui:edit_study_new' pk=row.record.pk %}"    method="post">
-                    {% csrf_token %}
-                    <input type="hidden" value="{% url 'researcher_ui:edit_study_new' pk=row.record.pk %}" id="form_modal_hidden_id{{row.record.pk}}" > 
-                
-                    <div class="overlay">
-                        <div class="cv-spinner">
-                            <span class="spinner"></span>
-                        </div>
-                    </div>
-
-                    <div class="modal-dialog" role="document">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title" id="exampleModalLabel">Update</h5>
-                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                    <span aria-hidden="true">&times;</span>
-                                </button>
-                            </div>
-    
-                            <div class="modal-body">
-                                <div>
-                                    <div class="form-group">
-                                        <label for="recipient-name" class="col-form-label">Subject Id</label>
-                                        <input type="text" class="form-control" name="subject_id" id="subject_id{{row.record.pk}}" value="{{row.record.subject_id}}">
-                                        <input type="hidden"  name="subject_id_old" id="subject_id_old{{row.record.pk}}" value="{{row.record.subject_id}}">
-                                        <span style="color: red; font-size: 12px;" id="subject_id_error_message{{row.record.pk}}">
-                                            <p></p>
-                                        </span>
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="recipient-name" class="col-form-label">Local Lab Id</label>
-                                        <input type="text" class="form-control" name="local_lab_id" id="local_lab_id{{row.record.pk}}" value="{{row.record.local_lab_id}}">
-                                    </div>
-                                    <div class="form-group">
-                                        <label for="recipient-name" class="col-form-label">Opted out of sharing</label>
-                                        <select name="opt_out" id="opt_out{{row.record.pk}}" class="form-group">
-                                            <option value="None" {% if row.record.opt_out == None %} selected{% endif %}>Unknown</option>
-                                            <option value="True" {% if row.record.opt_out == "Yes" %} selected {% endif %}> Yes</option>
-                                            <option value="False" {% if row.record.opt_out == "No" %} selected {% endif %}>  No</option>
-                                        </select>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="modal-footer">
-                                <button type="button" class="btn btn-secondary"  data-dismiss="modal">Close</button>
-                                <button type="button" onclick="edit_study_new('{{row.record.pk}}')" class="btn btn-primary">Save</button>
-                            </div>
-    
-                        </div>
-                    </div>
-                </form>
-            </div>          
-            <!--Modal-->
             {% for column, cell in row.items %}
-                {% if column|stringformat:"s" in '"Last modified","Expiration date","Creation date"' %}
-                    <td style="text-align: center;">
-                        <span id="converted_result{{forloop.parentloop.counter}}{{forloop.counter}}"></span>
-                        <script>document.getElementById('converted_result{{forloop.parentloop.counter}}{{forloop.counter}}').innerText = Convert_to_localtime("{{cell}}")</script>
-                    </td>
-                {% else %}
-                    <td style="text-align: center;">
-                        {{cell}}
-                    </td>
-                {% endif %}
+                <td class="wcdi-col-{{ column.name }}">{{ cell }}</td>
             {% endfor %}
-
-            <td>
-                <button type="button" class="btn-primary" style="border-radius:50%;" 
-                    onclick="edit_function({{row.record.pk}})">
-                    <span class="fa fa-edit"></span>
-                </button>
-            </td>
         </tr>
     {% endfor %}
     </tbody>
 </table>
+</div>
+
+{# Per-row edit dialogs. Kept outside the table so the markup stays valid. #}
+{% for row in table.paginated_rows %}
+<div class="modal" id="{{row.record.pk}}" tabindex="-1" role="dialog" aria-labelledby="edit-title-{{row.record.pk}}" aria-hidden="true">
+    <form action="{% url 'researcher_ui:edit_study_new' pk=row.record.pk %}" method="post">
+        {% csrf_token %}
+        <input type="hidden" value="{% url 'researcher_ui:edit_study_new' pk=row.record.pk %}" id="form_modal_hidden_id{{row.record.pk}}">
+
+        <div class="overlay">
+            <div class="cv-spinner">
+                <span class="spinner"></span>
+            </div>
+        </div>
+
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="edit-title-{{row.record.pk}}">Edit administration</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="subject_id{{row.record.pk}}" class="col-form-label">Participant ID</label>
+                        <input type="text" class="form-control" name="subject_id" id="subject_id{{row.record.pk}}" value="{{row.record.subject_id}}">
+                        <input type="hidden" name="subject_id_old" id="subject_id_old{{row.record.pk}}" value="{{row.record.subject_id}}">
+                        <span style="color: #a33a3a; font-size: 12px;" id="subject_id_error_message{{row.record.pk}}"></span>
+                    </div>
+                    <div class="form-group">
+                        <label for="local_lab_id{{row.record.pk}}" class="col-form-label">Lab ID <span class="wcdi-muted">(optional; any format)</span></label>
+                        <input type="text" class="form-control" name="local_lab_id" id="local_lab_id{{row.record.pk}}" value="{{row.record.local_lab_id|default_if_none:''}}">
+                    </div>
+                    <div class="form-group">
+                        <label for="opt_out{{row.record.pk}}" class="col-form-label">Opted out of data sharing</label>
+                        <select name="opt_out" id="opt_out{{row.record.pk}}" class="form-control">
+                            <option value="None" {% if row.record.opt_out == None %} selected{% endif %}>Unknown</option>
+                            <option value="True" {% if row.record.opt_out %} selected{% endif %}>Yes</option>
+                            <option value="False" {% if row.record.opt_out == False %} selected{% endif %}>No</option>
+                        </select>
+                        <small class="wcdi-muted">Set to Yes if this participant declined to have their de-identified data shared with Wordbank.</small>
+                    </div>
+
+                    <dl class="wcdi-edit-meta">
+                        <dt>Administration</dt><dd>#{{ row.record.repeat_num }}</dd>
+                        <dt>Last modified</dt><dd><time data-utc="{{ row.record.last_modified|date:'c' }}">{{ row.record.last_modified|date:'n/j/y' }}</time></dd>
+                        {% if current_study.confirm_completion %}
+                        <dt>Confirmed age &amp; completion</dt><dd>{% if row.record.analysis %}Yes{% elif row.record.analysis == False %}No{% else %}&mdash;{% endif %}</dd>
+                        {% endif %}
+                        {% if current_study.send_completion_flag_url %}
+                        <dt>Completion-flag response</dt><dd>{{ row.record.send_completion_flag_url_response|default_if_none:"—" }}</dd>
+                        {% endif %}
+                    </dl>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-link wcdi-nav-link" data-dismiss="modal">Cancel</button>
+                    <button type="button" onclick="edit_study_new('{{row.record.pk}}')" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </div>
+    </form>
+</div>
+{% endfor %}
+
+<script>
+    // Dates: server renders ISO (UTC) in data-utc; show the viewer's local time.
+    (function () {
+        document.querySelectorAll('time[data-utc]').forEach(function (t) {
+            var d = new Date(t.getAttribute('data-utc'));
+            if (isNaN(d)) return;
+            t.textContent = d.toLocaleDateString([], { year: '2-digit', month: 'numeric', day: 'numeric' });
+            t.title = d.toLocaleString([], { hour12: true });
+        });
+    })();
+    // Copy a participant link to the clipboard.
+    $(document).on('click', '.wcdi-copy-link', function () {
+        var btn = $(this), url = location.origin + btn.data('link');
+        var done = function () {
+            btn.addClass('copied').attr('title', 'Copied');
+            setTimeout(function () { btn.removeClass('copied').attr('title', "Copy the participant's link"); }, 1400);
+        };
+        if (navigator.clipboard) { navigator.clipboard.writeText(url).then(done); }
+        else {
+            var ta = document.createElement('textarea'); ta.value = url; document.body.appendChild(ta);
+            ta.select(); document.execCommand('copy'); document.body.removeChild(ta); done();
+        }
+    });
+</script>
 
 {% endblock table %}
 
 {% if table.page %}
     {% block pagination %}
-        <div class = "col-md-12" style = "float:none; display:inline-block; vertical-align:middle;">
+        <div class="wcdi-table-foot">
             <nav>{% bootstrap_pagination table.page url=request.get_full_path %}</nav>
             <a href="{% url 'researcher_ui:console_study' current_study.pk %}?view_all=all" id="view_all" class="btn btn-link" role="link">Show All</a>
         </div>

--- a/webcdi/researcher_UI/tests/test_views/views_tests.py
+++ b/webcdi/researcher_UI/tests/test_views/views_tests.py
@@ -248,7 +248,10 @@ class StudyCreateViewTest(TestCase):
 
         response = self.client.post(self.delete_url, payload)
         self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, self.delete_url)
+        # deleting a group lands on the dashboard, not the deleted group's page
+        self.assertRedirects(response, reverse("researcher_ui:console"))
+        self.delete_study.refresh_from_db()
+        self.assertFalse(self.delete_study.active)
 
 
 class AdminNewTest(TestCase):

--- a/webcdi/researcher_UI/views/views.py
+++ b/webcdi/researcher_UI/views/views.py
@@ -72,6 +72,9 @@ class StudyCreateView(LoginRequiredMixin, generic.CreateView):
                 #    return render(request, "researcher_UI/500_error.html", context)
                 if res:
                     return res
+                elif "delete-study" in request.POST:
+                    # the group is gone; land on the dashboard, not its empty page
+                    return redirect(reverse("researcher_ui:console"))
                 else:
                     target = reverse(
                         "researcher_ui:console_study", kwargs={"pk": study_obj.pk}

--- a/webcdi/static/cdi_forms/webcdi-theme.css
+++ b/webcdi/static/cdi_forms/webcdi-theme.css
@@ -735,3 +735,206 @@ hr {
   color: var(--wcdi-ink-soft);
 }
 .wcdi-ref a { word-break: break-all; }
+
+/* ---- study-group page: selection toolbar, table, dialogs (round-2 redesign) ---- */
+.wcdi-table-scroll {
+  overflow-x: auto;
+  max-width: 100%;
+}
+.wcdi-admin-table {
+  margin-bottom: 0;
+  border-collapse: separate; /* needed for sticky cells to keep their borders */
+  border-spacing: 0;
+}
+.wcdi-admin-table thead th {
+  white-space: nowrap;
+  background: var(--wcdi-card);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+.wcdi-admin-table td {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  background: var(--wcdi-card);
+}
+.wcdi-admin-table tbody tr:hover td {
+  background: var(--wcdi-primary-wash);
+}
+/* pinned identity columns: select, edit, participant ID */
+.wcdi-admin-table .wcdi-col-select_col,
+.wcdi-admin-table .wcdi-col-edit,
+.wcdi-admin-table .wcdi-col-subject_id {
+  position: sticky;
+  z-index: 1;
+}
+.wcdi-admin-table thead .wcdi-col-select_col,
+.wcdi-admin-table thead .wcdi-col-edit,
+.wcdi-admin-table thead .wcdi-col-subject_id {
+  z-index: 3;
+}
+.wcdi-admin-table .wcdi-col-select_col { left: 0; width: 36px; }
+.wcdi-admin-table .wcdi-col-edit { left: 36px; width: 76px; }
+.wcdi-admin-table .wcdi-col-subject_id { left: 112px; font-weight: 600; }
+.wcdi-admin-table .wcdi-col-subject_id::after {
+  /* soft edge that appears when the table scrolls under the pinned columns */
+  content: "";
+  position: absolute;
+  top: 0; right: -1px; bottom: 0;
+  width: 1px;
+  background: var(--wcdi-line);
+}
+.wcdi-admin-table .wcdi-col-repeat_num { text-align: center; }
+
+.wcdi-row-edit {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid var(--wcdi-line);
+  background: var(--wcdi-card);
+  color: var(--wcdi-primary);
+  font-size: 12.5px;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 3px 8px;
+  cursor: pointer;
+  line-height: 1.3;
+}
+.wcdi-row-edit:hover {
+  border-color: var(--wcdi-primary);
+  background: var(--wcdi-primary-wash);
+}
+.wcdi-link-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.wcdi-copy-link {
+  border: 1px solid var(--wcdi-line);
+  background: var(--wcdi-card);
+  color: var(--wcdi-ink-soft);
+  border-radius: 6px;
+  width: 26px;
+  height: 24px;
+  cursor: pointer;
+  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.wcdi-copy-link:hover { color: var(--wcdi-primary); border-color: var(--wcdi-primary); }
+.wcdi-copy-link.copied { color: var(--wcdi-check); border-color: var(--wcdi-check); }
+
+.wcdi-badge {
+  display: inline-block;
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 2px 9px;
+  border-radius: 999px;
+  white-space: nowrap;
+  line-height: 1.5;
+}
+.wcdi-badge-scored   { background: var(--wcdi-primary-wash); color: var(--wcdi-primary); }
+.wcdi-badge-done     { background: var(--wcdi-check-wash);   color: var(--wcdi-check); }
+.wcdi-badge-survey   { background: #fbf1e2; color: #8a5a14; }
+.wcdi-badge-progress { background: #fbf1e2; color: #8a5a14; }
+.wcdi-badge-new      { background: #eef1f4; color: var(--wcdi-ink-soft); }
+.wcdi-badge-expired  { background: #fbeaea; color: #a33a3a; }
+.wcdi-badge-inactive { background: #eef1f4; color: var(--wcdi-ink-soft); text-decoration: line-through; }
+.wcdi-chip {
+  display: inline-block;
+  font-size: 10.5px;
+  color: var(--wcdi-ink-soft);
+  border: 1px solid var(--wcdi-line);
+  border-radius: 4px;
+  padding: 0 5px;
+  margin-left: 6px;
+  vertical-align: 1px;
+}
+.wcdi-table-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 8px;
+}
+.wcdi-table-foot nav { margin: 0; }
+.wcdi-table-foot .pagination { margin: 0; }
+
+.wcdi-edit-meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 14px;
+  font-size: 13px;
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--wcdi-line);
+}
+.wcdi-edit-meta dt { color: var(--wcdi-ink-soft); font-weight: 500; }
+.wcdi-edit-meta dd { margin: 0; }
+
+/* download menu: scope header + disabled-with-reason items */
+.wcdi-download-menu { min-width: 320px; }
+.wcdi-download-menu .dropdown-header {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--wcdi-ink-soft);
+}
+.wcdi-download-menu .wcdi-scope-selected { color: var(--wcdi-primary); }
+.wcdi-download-menu .dropdown-item.disabled,
+.wcdi-download-menu .dropdown-item:disabled { color: var(--wcdi-ink-soft); opacity: 0.75; cursor: default; }
+.wcdi-needs-hint { font-size: 11.5px; color: var(--wcdi-ink-soft); }
+
+.wcdi-selection-label { white-space: nowrap; }
+.wcdi-danger-text { color: #a33a3a; }
+.wcdi-btn-danger-solid, .wcdi-btn-danger-solid:focus {
+  background: #a33a3a;
+  border-color: #a33a3a;
+  color: #fff;
+  font-weight: 600;
+}
+.wcdi-btn-danger-solid:hover:not(:disabled) { background: #8a2f2f; border-color: #8a2f2f; color: #fff; }
+.wcdi-btn-danger-solid:disabled { opacity: 0.5; background: #a33a3a; border-color: #a33a3a; color: #fff; }
+
+/* danger zone (group settings page) */
+.wcdi-danger-zone {
+  border: 1px solid #d9a3a3;
+  border-radius: var(--wcdi-radius);
+  background: var(--wcdi-card);
+  padding: 14px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 28px;
+}
+.wcdi-danger-zone h2 { color: #a33a3a; font-size: 16px; margin: 0 0 2px; }
+.wcdi-danger-zone p { margin: 0; font-size: 13.5px; color: var(--wcdi-ink-soft); max-width: 56ch; }
+
+/* add-administrations dialog: method tabs */
+.wcdi-method-pills { gap: 6px; margin-bottom: 14px; }
+.wcdi-method-pills .nav-link {
+  font-size: 13.5px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--wcdi-line);
+  color: var(--wcdi-ink);
+  background: var(--wcdi-paper);
+}
+.wcdi-method-pills .nav-link.active {
+  background: var(--wcdi-primary);
+  border-color: var(--wcdi-primary);
+  color: #fff;
+  font-weight: 600;
+}
+.wcdi-method-pills .wcdi-method-pill-sep { margin-left: auto; }
+.wcdi-method-pills .wcdi-method-pill-sep .nav-link:not(.active) { border-style: dashed; color: var(--wcdi-ink-soft); }
+.wcdi-method-panels { min-height: 120px; }
+.wcdi-method-help { font-size: 14px; color: var(--wcdi-ink-soft); margin: 0 0 10px; }
+.wcdi-method-label { font-size: 13px; font-weight: 600; margin-bottom: 4px; display: block; }
+.wcdi-link-row { display: flex; gap: 8px; align-items: center; }
+.wcdi-link-row input { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; }

--- a/webcdi/webcdi/templates/webcdi/documentation.html
+++ b/webcdi/webcdi/templates/webcdi/documentation.html
@@ -71,7 +71,7 @@
 
     <div class="wcdi-card-panel" style="margin-bottom:16px" id="groups">
         <h2>Creating an administration group (study) and its options</h2>
-        <p>Once you have selected your instruments, click <strong>+ New administration group</strong> on your
+        <p>Once you have selected your instruments, click <strong>New administration group</strong> on your
             dashboard. Give the group a name and choose the instrument from the dropdown. Each group administers
             exactly one instrument.</p>
         <p class="alert alert-info">Tip: In some cases, you might be administering multiple instruments to a single
@@ -158,43 +158,46 @@
                 standard message. You have the option to add to this message or replace it altogether.</li>
         </ul>
         <p>Click <strong>Save</strong>. You can change any of these options except the instrument later, from the
-            group's page via <strong>Update Group</strong>. Open a group from the cards on your dashboard (or the group
+            group's page via <strong>Group settings</strong> (which is also where you delete a group). Open a group from the cards on your dashboard (or the group
             switcher at the top right of any group page) to see its administrations.</p>
     </div>
 
     <div class="wcdi-card-panel" style="margin-bottom:16px" id="participants">
         <h2>Adding administrations</h2>
-        <p>On a group's page, click <strong>Add Administrations</strong>. There are several ways to add
-            participants. The most typical use-case is to type your own list of participant IDs into the
-            <strong>Your Own Participant ID(s)</strong> box, e.g., 1111, 1112, 1113, etc. These IDs must be all
+        <p>On a group's page, click <strong>Add administrations</strong> and pick a method from the tabs. The most typical
+            use-case is <strong>Enter participant IDs</strong>: type your own list of IDs, e.g., 1111, 1112, 1113, etc. These IDs must be all
             numeric (i.e., no letters). If you enter an ID that already exists in the group, the system assumes it is
             the same child and creates an additional administration for that ID.</p>
         <p class="alert alert-info">Tip: You can also add another administration for an existing participant by
-            ticking their row in the table and clicking <strong>Re-administer</strong>. A new administration of that
+            ticking their row in the table and clicking <strong>Re-administer</strong>. To remove administrations,
+            tick them and click <strong>Delete</strong>. A new administration of that
             ID will appear in the list.</p>
-        <p>You can also autogenerate a list of IDs (e.g., if you are running several participants at a site on the
-            same day, such as a Children's Museum), upload a CSV of IDs, or use a single reusable link. The single
-            reusable link is designed to be used with external platforms, e.g., Facebook or Prolific: anyone who opens
-            it creates a new administration with a Web-CDI-generated ID. Please contact the Web-CDI team for more
-            information about using single reusable links.</p>
+        <p>The other tabs let Web-CDI <strong>generate IDs for you</strong> (e.g., if you are running several participants
+            at a site on the same day, such as a Children's Museum), <strong>upload a CSV of IDs</strong>, or copy a
+            <strong>reusable link</strong>. The reusable link is designed for external platforms, e.g., Facebook or
+            Prolific: anyone who opens it creates a new administration with a Web-CDI-generated ID. Please contact the
+            Web-CDI team for more information about using reusable links. The last tab, <strong>Import completed
+            responses</strong>, imports the CSV exported by the English MB-CDI fillable PDFs as already-completed
+            administrations.</p>
         <p class="alert alert-info">Tip: When you enter IDs into Web-CDI, these should be meaningful to you, as it is
             the only way for you to track your participants within Web-CDI. You can also record additional information
-            in the <strong>Local Lab ID</strong> field &mdash; which has no constraints on format (it can contain letters)
-            &mdash; by clicking the pencil (edit) button on a row.</p>
+            in the <strong>Lab ID</strong> field &mdash; which has no constraints on format (it can contain letters)
+            &mdash; by clicking <strong>Edit</strong> on a row.</p>
     </div>
 
     <div class="wcdi-card-panel" style="margin-bottom:16px" id="tracking">
         <h2>Tracking completion</h2>
-        <p>The table on the group's page lists each administration with its number (1st, 2nd, etc.), the link you
-            send to the respondent, the local lab ID (if used), and when the link was created, last modified, and will
-            expire. A cross means the background form or the CDI itself has not yet been completed by the respondent;
-            a checkmark means it has. You can use the last-modified time to see whether a respondent has opened the
-            link and started completing the form. You may need to refresh the page to see new checkmarks. A checkmark
-            under <strong>Scored</strong> indicates that the scores have been computed by the system and are ready for
-            download.</p>
+        <p>The table on the group's page lists each administration with its number (1st, 2nd, etc.), the
+            participant's link (<strong>Open</strong> to preview it, or the copy button to paste it into an email), the
+            lab ID (if used), its <strong>Status</strong>, and when it was created, expires, and was completed. Status
+            runs <em>Not started &rarr; In progress</em> (background info done, CDI under way) <em>&rarr; Completed
+            &rarr; Scored</em> (scores computed by the system and ready for download); a link that ran out before the
+            form was finished shows <em>Expired</em>. Hover the status for the last time the respondent touched the
+            form. You may need to refresh the page to see changes.</p>
         <p class="alert alert-info">Tip: If an individual participant has not given consent for their data to be
-            shared with Wordbank &mdash; even though your group, in general, has opted in for sharing &mdash; click the
-            pencil (edit) button on their row and set <strong>Opted out of sharing</strong> to Yes. You must do this
+            shared with Wordbank &mdash; even though your group, in general, has opted in for sharing &mdash; click
+            <strong>Edit</strong> on their row and set <strong>Opted out of data sharing</strong> to Yes (an
+            <em>opt-out</em> chip then appears next to the status). You must do this
             for every administration: the setting does not carry over when a new administration is added with the same
             subject ID.</p>
     </div>
@@ -202,7 +205,8 @@
     <div class="wcdi-card-panel" style="margin-bottom:16px" id="downloading">
         <h2>Downloading data &amp; scoring</h2>
         <p>After your respondents have completed their CDIs, you have several options for how to download their
-            responses and scores. The <strong>Download All</strong> menu covers every administration in the group:</p>
+            responses and scores, all under the <strong>Download</strong> menu. With no rows ticked it covers every
+            administration in the group; tick rows first and the same menu applies to just those rows:</p>
         <ul>
             <li><strong>Items and Summary Scores/Percentiles (csv):</strong> The csv output will first have all of the
                 basic metadata, the demographic responses, and then all of the responses for each item. Lastly, the
@@ -220,16 +224,14 @@
             <li><strong>Summary Scores/Percentiles (csv):</strong> The same as the first option but without the
                 individual item responses.</li>
         </ul>
-        <p>To download only certain participants, tick the box at the left of their rows and use the
-            <strong>Download</strong> menu next to "With selected". It offers the same three csv formats for just
-            those rows, plus:</p>
+        <p>Two items need a selection (they are per-participant outputs), so tick rows first:</p>
         <ul>
             <li>The <strong>Clinical Report (pdf)</strong> gives scores and percentiles for the selected administrations
                 in a friendly report format that is appropriate to share with the families or other professionals.
                 This report is currently available for the English and Spanish long forms. A version with adjusted
                 ages is also offered.</li>
-            <li><strong>Links only (csv)</strong> downloads just the participant links for the selected rows, which is
-                useful for mail-merging invitations.</li>
+            <li><strong>Participant links (csv)</strong> downloads just the participant links for the selected rows
+                (tick the header checkbox for all of them), which is useful for mail-merging invitations.</li>
         </ul>
     </div>
 


### PR DESCRIPTION
Part B of the round-2 feedback (the approved group-page proposal), stacked on #657. Design proposal with before/after mockups: https://claude.ai/code/artifact/7a4700c1-5e9d-4d52-ba64-299ee58981c6

**No POST names or handlers change.** Everything is templates, CSS, and small JS — with one deliberate 3-line backend tweak, called out below. Principle throughout: *one verb, one place; scope follows the selection; destructive actions look destructive and ask properly.*

### Toolbar
- One primary **Add administrations** (the split-button arrow is gone; the importer moved inside the dialog).
- **One Download menu.** Nothing ticked → posts the whole-group names (`download-study-csv`…); rows ticked → the same items post the selected-rows names (`download-selected`…), and a scope header says which. Clinical reports and participant links genuinely need a selection (per-row PDFs; no whole-group links handler), so they stay visible but disabled with "select rows first".
- **Group settings** replaces "Update Group".
- Selection row: **"N selected" · Re-administer · Delete**. Delete opens a count-stating dialog instead of `confirm()`.
- **Delete group moved** off the page into the Group settings danger zone (see below).

### Table: 15 columns → 10
- Pinned left: checkbox · **Edit** (pencil + label) · Participant ID. Sticky header. Card scrolls horizontally on narrow screens with the pinned columns holding; at 1400 px the table now fits with no overflow at all.
- **Status badge** replaces Scored / Completed / Completed background info / Completed survey / Is active: *Not started → In progress → Survey pending → Completed → Scored*, plus *Expired* and *Inactive*; tooltip carries last activity. **Opt-out** appears as a chip next to the badge only when set.
- Link cell: **Open** (new tab) + **copy** button.
- Created / Expires / Completed in the viewer's local time via `data-utc`.
- Last modified, confirmed-completion, and completion-flag response move into the row's **Edit administration** dialog as read-only fields.

### Group settings page
- Titled "Group settings · name"; **danger zone** at the bottom with the GitHub-style **type-the-name-to-confirm** dialog, posting the existing `delete-study` action.
- ⚠️ **The one backend change:** after `delete-study`, `StudyCreateView.post` now redirects to the dashboard instead of the deleted group's page (3 lines; `test_post_delete_study` updated to the new contract and also asserts the soft-delete). Worth a look, @HenryMehta.
- Note: both deletes are **soft** in the backend (`is_active`/`active=False`), so the copy says "cannot be undone from your account" rather than promising erasure.

### Add administrations dialog
- Titled "Add administrations"; **method tabs** (Enter IDs / Generate / Upload CSV / Reusable link / External source / Import completed responses) with one short sentence each, replacing the duplicated wall of text. **Field names are unchanged**, so `admin_new_fun`'s field-based dispatch is untouched. Footer button follows the tab; link tabs get copy buttons; the importer tab hands off to the (retitled, slimmed) import dialog.

### Verification (all local, against this branch)
- Selection logic: count, enablement, menu name-switching and scope header all tracked ticking 0 → 3 → 2 → 0 rows and the header select-all (20).
- All eight download / re-administer POST variants return the right CSV / redirect through the real handlers.
- Delete-selected soft-deletes rows; delete-group (type-to-confirm arms only on exact match) soft-deletes and lands on the dashboard.
- Add dialog: tab/footer states correct across all tabs; a real submit through the dialog's own JS created two administrations.
- Status badges verified for Scored / Completed / In progress / Expired and the opt-out chip; row Edit save round-trips Lab ID + opt-out.
- Pinned columns hold at 768 px; page never scrolls sideways.
- Full fast suite (CI command): **253 tests OK** after the one test update above.

### Known follow-ups
- The Selenium `test_delete_study` (and the locator rot already tracked in #648) needs rewriting for the new flow. I kept `id_add_participants`, `id_update_study`, `id_new_study`, the dialog field ids, and `id_modal_submit_btn` stable so most of those tests survive.
- The theme CSS is served without cache-busting, so testers may need a hard reload to see the new styles (bit me repeatedly). Consider `ManifestStaticFilesStorage` as a separate change.
- `checked_only()` in `researcher_UI.js` is no longer called (superseded by the selection sync here); left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)